### PR TITLE
feat: add theme system with Original, Dark and Light modes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route } from 'react-router-dom'
 import { AuthProvider } from './contexts/AuthContext'
+import { ThemeProvider } from './contexts/ThemeContext'
 import { PrivateRoute, AdminRoute } from './components/PrivateRoute'
 import Layout from './components/Layout'
 
@@ -70,6 +71,7 @@ import AdminUsuarios from './pages/AdminUsuarios'
 
 export default function App() {
   return (
+    <ThemeProvider>
     <AuthProvider>
       <Routes>
         {/* ── Públicas ──────────────────────────────────────── */}
@@ -158,5 +160,6 @@ export default function App() {
         </Route>
       </Routes>
     </AuthProvider>
+    </ThemeProvider>
   )
 }

--- a/frontend/src/components/EstoqueLayout.tsx
+++ b/frontend/src/components/EstoqueLayout.tsx
@@ -4,7 +4,9 @@ import {
   ClipboardList, Landmark, LogOut, LayoutGrid,
 } from 'lucide-react'
 import { useAuth, ROLE_LABEL, ROLE_COLOR } from '../contexts/AuthContext'
+import { useTheme } from '../contexts/ThemeContext'
 import LogoTeg from './LogoTeg'
+import ThemeToggle from './ThemeToggle'
 
 const NAV = [
   { to: '/estoque',               icon: LayoutDashboard, label: 'Painel',          end: true  },
@@ -33,12 +35,14 @@ function getInitials(name: string): string {
 
 export default function EstoqueLayout() {
   const { perfil, signOut, role } = useAuth()
+  const { isDark, isLightSidebar } = useTheme()
   const navigate = useNavigate()
 
   const nome      = perfil?.nome ?? 'Usuário'
   const initials  = getInitials(nome)
   const avatarBg  = getAvatarColor(nome)
   const firstName = nome.split(' ')[0]
+  const ls = isLightSidebar
 
   async function handleLogout() {
     await signOut()
@@ -48,48 +52,51 @@ export default function EstoqueLayout() {
   function sidebarLinkClass({ isActive }: { isActive: boolean }) {
     const base = 'flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-semibold transition-all duration-150 border'
     if (isActive)
-      return `${base} bg-blue-500/15 text-blue-300 border-blue-500/25`
-    return `${base} text-slate-400 hover:text-slate-100 hover:bg-white/6 border-transparent`
+      return `${base} ${ls ? 'bg-blue-50 text-blue-700 border-blue-200' : 'bg-blue-500/15 text-blue-300 border-blue-500/25'}`
+    return `${base} ${ls ? 'text-slate-500 hover:text-slate-800 hover:bg-slate-50 border-transparent' : 'text-slate-400 hover:text-slate-100 hover:bg-white/6 border-transparent'}`
   }
 
   function bottomLinkClass({ isActive }: { isActive: boolean }) {
     const base = 'flex flex-col items-center py-2 px-1.5 rounded-xl text-[9px] font-semibold transition-all duration-150 min-w-[40px]'
     if (isActive)
-      return `${base} text-blue-400 bg-blue-400/10`
-    return `${base} text-slate-500 hover:text-slate-300`
+      return `${base} ${ls ? 'text-blue-600 bg-blue-50' : 'text-blue-400 bg-blue-400/10'}`
+    return `${base} ${ls ? 'text-slate-400 hover:text-slate-600' : 'text-slate-500 hover:text-slate-300'}`
   }
 
   return (
-    <div className="min-h-screen bg-slate-100">
+    <div className={`min-h-screen ${isDark ? 'bg-[#0c1222]' : ls ? 'bg-slate-50' : 'bg-slate-100'}`}>
 
       {/* ── DESKTOP SIDEBAR ────────────────────────────────────── */}
       <aside
-        className="hidden lg:flex flex-col fixed left-0 top-0 h-full w-64 bg-[#0B1523] z-40"
-        style={{ boxShadow: '4px 0 24px rgba(0,0,0,0.4)' }}
+        className={`hidden lg:flex flex-col fixed left-0 top-0 h-full w-64 z-40
+          ${ls ? 'bg-white border-r border-slate-200/80' : 'bg-[#0B1523]'}`}
+        style={{ boxShadow: ls ? '1px 0 0 rgba(0,0,0,0.05)' : '4px 0 24px rgba(0,0,0,0.4)' }}
       >
-        <div className="px-4 pt-5 pb-4 border-b border-white/[0.06]">
+        <div className={`px-4 pt-5 pb-4 border-b ${ls ? 'border-slate-100' : 'border-white/[0.06]'}`}>
           <div className="flex items-center gap-3 mb-4">
             <LogoTeg size={38} animated={false} />
             <div>
-              <p className="text-white font-black text-lg tracking-tight leading-none">TEG+</p>
-              <p className="text-[10px] text-slate-500 font-medium mt-0.5">ERP Sistema</p>
+              <p className={`font-black text-lg tracking-tight leading-none ${ls ? 'text-slate-800' : 'text-white'}`}>TEG+</p>
+              <p className={`text-[10px] font-medium mt-0.5 ${ls ? 'text-slate-400' : 'text-slate-500'}`}>ERP Sistema</p>
             </div>
           </div>
           <button
             onClick={() => navigate('/')}
-            className="w-full flex items-center gap-2.5 bg-blue-500/10 border border-blue-500/25
-              rounded-xl px-3 py-2.5 hover:bg-blue-500/18 hover:border-blue-500/40
-              transition-all duration-150 group"
+            className={`w-full flex items-center gap-2.5 rounded-xl px-3 py-2.5 transition-all duration-150 group border
+              ${ls
+                ? 'bg-blue-50 border-blue-200 hover:bg-blue-100 hover:border-blue-300'
+                : 'bg-blue-500/10 border-blue-500/25 hover:bg-blue-500/18 hover:border-blue-500/40'
+              }`}
             title="Trocar módulo"
           >
             <span className="text-lg leading-none">📦</span>
             <div className="flex-1 text-left">
-              <p className="text-xs font-bold text-blue-300 leading-none">Estoque</p>
-              <p className="text-[9px] text-blue-500/60 mt-0.5">Módulo ativo</p>
+              <p className={`text-xs font-bold leading-none ${ls ? 'text-blue-700' : 'text-blue-300'}`}>Estoque</p>
+              <p className={`text-[9px] mt-0.5 ${ls ? 'text-blue-500/60' : 'text-blue-500/60'}`}>Módulo ativo</p>
             </div>
             <LayoutGrid
               size={13}
-              className="text-blue-500/50 group-hover:text-blue-400 transition-colors shrink-0"
+              className={`transition-colors shrink-0 ${ls ? 'text-blue-400 group-hover:text-blue-500' : 'text-blue-500/50 group-hover:text-blue-400'}`}
             />
           </button>
         </div>
@@ -103,14 +110,19 @@ export default function EstoqueLayout() {
           ))}
         </nav>
 
-        <div className="px-3 pb-4 pt-2 border-t border-white/[0.06]">
-          <div className="flex items-center gap-2.5 px-2 py-2.5 rounded-xl hover:bg-white/4 transition-colors">
+        {/* Theme toggle */}
+        <div className={`px-3 py-2 border-t ${ls ? 'border-slate-100' : 'border-white/[0.06]'}`}>
+          <ThemeToggle variant={ls ? 'light' : 'dark'} />
+        </div>
+
+        <div className={`px-3 pb-4 pt-2 border-t ${ls ? 'border-slate-100' : 'border-white/[0.06]'}`}>
+          <div className={`flex items-center gap-2.5 px-2 py-2.5 rounded-xl transition-colors ${ls ? 'hover:bg-slate-50' : 'hover:bg-white/4'}`}>
             <div className={`w-9 h-9 rounded-full flex items-center justify-center
-              text-white text-xs font-extrabold shrink-0 ring-2 ring-white/10 ${avatarBg}`}>
+              text-white text-xs font-extrabold shrink-0 ring-2 ${ls ? 'ring-slate-200' : 'ring-white/10'} ${avatarBg}`}>
               {initials}
             </div>
             <div className="flex-1 min-w-0">
-              <p className="text-[13px] font-semibold text-slate-200 truncate leading-none">
+              <p className={`text-[13px] font-semibold truncate leading-none ${ls ? 'text-slate-700' : 'text-slate-200'}`}>
                 {firstName}
               </p>
               <span className={`text-[10px] font-medium mt-0.5 inline-block ${ROLE_COLOR[role].text}`}>
@@ -119,8 +131,8 @@ export default function EstoqueLayout() {
             </div>
             <button
               onClick={handleLogout}
-              className="w-7 h-7 rounded-lg bg-white/5 flex items-center justify-center
-                text-slate-500 hover:text-red-400 hover:bg-red-400/10 transition-all shrink-0"
+              className={`w-7 h-7 rounded-lg flex items-center justify-center transition-all shrink-0
+                ${ls ? 'bg-slate-100 text-slate-400 hover:text-red-500 hover:bg-red-50' : 'bg-white/5 text-slate-500 hover:text-red-400 hover:bg-red-400/10'}`}
               title="Sair"
             >
               <LogOut size={13} />
@@ -134,26 +146,26 @@ export default function EstoqueLayout() {
 
         {/* Mobile header */}
         <header
-          className="lg:hidden bg-[#0B1523] text-white px-4 py-3 sticky top-0 z-30
-            flex items-center gap-3"
-          style={{ boxShadow: '0 2px 20px rgba(0,0,0,0.4)' }}
+          className={`lg:hidden px-4 py-3 sticky top-0 z-30 flex items-center gap-3
+            ${ls ? 'bg-white border-b border-slate-200' : 'bg-[#0B1523] text-white'}`}
+          style={{ boxShadow: ls ? '0 1px 3px rgba(0,0,0,0.05)' : '0 2px 20px rgba(0,0,0,0.4)' }}
         >
           <button onClick={() => navigate('/')} className="shrink-0" title="Trocar módulo">
             <LogoTeg size={30} animated={false} />
           </button>
           <div className="flex-1 min-w-0">
             <div className="flex items-baseline gap-1.5">
-              <h1 className="text-sm font-black text-white leading-none">TEG+</h1>
-              <span className="text-[9px] text-blue-400/70 font-semibold">Estoque</span>
+              <h1 className={`text-sm font-black leading-none ${ls ? 'text-slate-800' : 'text-white'}`}>TEG+</h1>
+              <span className={`text-[9px] font-semibold ${ls ? 'text-blue-500' : 'text-blue-400/70'}`}>Estoque</span>
             </div>
           </div>
           <div className={`w-8 h-8 rounded-full flex items-center justify-center
-            text-white text-xs font-extrabold ring-2 ring-white/10 ${avatarBg}`}>
+            text-white text-xs font-extrabold ring-2 ${ls ? 'ring-slate-200' : 'ring-white/10'} ${avatarBg}`}>
             {initials}
           </div>
           <button onClick={handleLogout}
-            className="w-7 h-7 rounded-lg bg-white/10 flex items-center justify-center
-              text-slate-400 hover:text-white hover:bg-white/20 transition-all shrink-0">
+            className={`w-7 h-7 rounded-lg flex items-center justify-center transition-all shrink-0
+              ${ls ? 'bg-slate-100 text-slate-400 hover:text-slate-600 hover:bg-slate-200' : 'bg-white/10 text-slate-400 hover:text-white hover:bg-white/20'}`}>
             <LogOut size={13} />
           </button>
         </header>
@@ -165,8 +177,11 @@ export default function EstoqueLayout() {
         </main>
 
         {/* Mobile bottom nav */}
-        <nav className="lg:hidden fixed bottom-0 inset-x-0 z-40 glass-dark border-t border-white/[0.06]"
-          style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}>
+        <nav
+          className={`lg:hidden fixed bottom-0 inset-x-0 z-40 border-t
+            ${ls ? 'glass-light border-slate-200' : 'glass-dark border-white/[0.06]'}`}
+          style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+        >
           <div className="flex justify-around max-w-lg mx-auto px-1 py-1">
             {NAV.map(({ to, icon: Icon, label, end }) => (
               <NavLink key={to} to={to} end={end} className={bottomLinkClass}>

--- a/frontend/src/components/FinanceiroLayout.tsx
+++ b/frontend/src/components/FinanceiroLayout.tsx
@@ -4,7 +4,9 @@ import {
   BarChart3, Users, LogOut, LayoutGrid, DollarSign, Settings,
 } from 'lucide-react'
 import { useAuth, ROLE_LABEL, ROLE_COLOR } from '../contexts/AuthContext'
+import { useTheme } from '../contexts/ThemeContext'
 import LogoTeg from './LogoTeg'
+import ThemeToggle from './ThemeToggle'
 
 const NAV = [
   { to: '/financeiro',                icon: LayoutDashboard, label: 'Painel',          end: true  },
@@ -36,12 +38,14 @@ function getInitials(name: string): string {
 
 export default function FinanceiroLayout() {
   const { perfil, signOut, role } = useAuth()
+  const { isDark, isLightSidebar } = useTheme()
   const navigate = useNavigate()
 
   const nome      = perfil?.nome ?? 'Usuário'
   const initials  = getInitials(nome)
   const avatarBg  = getAvatarColor(nome)
   const firstName = nome.split(' ')[0]
+  const ls = isLightSidebar
 
   async function handleLogout() {
     await signOut()
@@ -51,48 +55,51 @@ export default function FinanceiroLayout() {
   function sidebarLinkClass({ isActive }: { isActive: boolean }) {
     const base = 'flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-semibold transition-all duration-150 border'
     if (isActive)
-      return `${base} bg-emerald-500/15 text-emerald-300 border-emerald-500/25`
-    return `${base} text-slate-400 hover:text-slate-100 hover:bg-white/6 border-transparent`
+      return `${base} ${ls ? 'bg-emerald-50 text-emerald-700 border-emerald-200' : 'bg-emerald-500/15 text-emerald-300 border-emerald-500/25'}`
+    return `${base} ${ls ? 'text-slate-500 hover:text-slate-800 hover:bg-slate-50 border-transparent' : 'text-slate-400 hover:text-slate-100 hover:bg-white/6 border-transparent'}`
   }
 
   function bottomLinkClass({ isActive }: { isActive: boolean }) {
     const base = 'flex flex-col items-center py-2 px-1.5 rounded-xl text-[9px] font-semibold transition-all duration-150 min-w-[40px]'
     if (isActive)
-      return `${base} text-emerald-400 bg-emerald-400/10`
-    return `${base} text-slate-500 hover:text-slate-300`
+      return `${base} ${ls ? 'text-emerald-600 bg-emerald-50' : 'text-emerald-400 bg-emerald-400/10'}`
+    return `${base} ${ls ? 'text-slate-400 hover:text-slate-600' : 'text-slate-500 hover:text-slate-300'}`
   }
 
   return (
-    <div className="min-h-screen bg-slate-100">
+    <div className={`min-h-screen ${isDark ? 'bg-[#0c1222]' : ls ? 'bg-slate-50' : 'bg-slate-100'}`}>
 
       {/* ── DESKTOP SIDEBAR ────────────────────────────────────── */}
       <aside
-        className="hidden lg:flex flex-col fixed left-0 top-0 h-full w-64 bg-[#0B1523] z-40"
-        style={{ boxShadow: '4px 0 24px rgba(0,0,0,0.4)' }}
+        className={`hidden lg:flex flex-col fixed left-0 top-0 h-full w-64 z-40
+          ${ls ? 'bg-white border-r border-slate-200/80' : 'bg-[#0B1523]'}`}
+        style={{ boxShadow: ls ? '1px 0 0 rgba(0,0,0,0.05)' : '4px 0 24px rgba(0,0,0,0.4)' }}
       >
-        <div className="px-4 pt-5 pb-4 border-b border-white/[0.06]">
+        <div className={`px-4 pt-5 pb-4 border-b ${ls ? 'border-slate-100' : 'border-white/[0.06]'}`}>
           <div className="flex items-center gap-3 mb-4">
             <LogoTeg size={38} animated={false} />
             <div>
-              <p className="text-white font-black text-lg tracking-tight leading-none">TEG+</p>
-              <p className="text-[10px] text-slate-500 font-medium mt-0.5">ERP Sistema</p>
+              <p className={`font-black text-lg tracking-tight leading-none ${ls ? 'text-slate-800' : 'text-white'}`}>TEG+</p>
+              <p className={`text-[10px] font-medium mt-0.5 ${ls ? 'text-slate-400' : 'text-slate-500'}`}>ERP Sistema</p>
             </div>
           </div>
           <button
             onClick={() => navigate('/')}
-            className="w-full flex items-center gap-2.5 bg-emerald-500/10 border border-emerald-500/25
-              rounded-xl px-3 py-2.5 hover:bg-emerald-500/18 hover:border-emerald-500/40
-              transition-all duration-150 group"
+            className={`w-full flex items-center gap-2.5 rounded-xl px-3 py-2.5 transition-all duration-150 group border
+              ${ls
+                ? 'bg-emerald-50 border-emerald-200 hover:bg-emerald-100 hover:border-emerald-300'
+                : 'bg-emerald-500/10 border-emerald-500/25 hover:bg-emerald-500/18 hover:border-emerald-500/40'
+              }`}
             title="Trocar módulo"
           >
             <span className="text-lg leading-none">💰</span>
             <div className="flex-1 text-left">
-              <p className="text-xs font-bold text-emerald-300 leading-none">Financeiro</p>
-              <p className="text-[9px] text-emerald-500/60 mt-0.5">Módulo ativo</p>
+              <p className={`text-xs font-bold leading-none ${ls ? 'text-emerald-700' : 'text-emerald-300'}`}>Financeiro</p>
+              <p className={`text-[9px] mt-0.5 ${ls ? 'text-emerald-500/60' : 'text-emerald-500/60'}`}>Módulo ativo</p>
             </div>
             <LayoutGrid
               size={13}
-              className="text-emerald-500/50 group-hover:text-emerald-400 transition-colors shrink-0"
+              className={`transition-colors shrink-0 ${ls ? 'text-emerald-400 group-hover:text-emerald-500' : 'text-emerald-500/50 group-hover:text-emerald-400'}`}
             />
           </button>
         </div>
@@ -106,14 +113,19 @@ export default function FinanceiroLayout() {
           ))}
         </nav>
 
-        <div className="px-3 pb-4 pt-2 border-t border-white/[0.06]">
-          <div className="flex items-center gap-2.5 px-2 py-2.5 rounded-xl hover:bg-white/4 transition-colors">
+        {/* Theme toggle */}
+        <div className={`px-3 py-2 border-t ${ls ? 'border-slate-100' : 'border-white/[0.06]'}`}>
+          <ThemeToggle variant={ls ? 'light' : 'dark'} />
+        </div>
+
+        <div className={`px-3 pb-4 pt-2 border-t ${ls ? 'border-slate-100' : 'border-white/[0.06]'}`}>
+          <div className={`flex items-center gap-2.5 px-2 py-2.5 rounded-xl transition-colors ${ls ? 'hover:bg-slate-50' : 'hover:bg-white/4'}`}>
             <div className={`w-9 h-9 rounded-full flex items-center justify-center
-              text-white text-xs font-extrabold shrink-0 ring-2 ring-white/10 ${avatarBg}`}>
+              text-white text-xs font-extrabold shrink-0 ring-2 ${ls ? 'ring-slate-200' : 'ring-white/10'} ${avatarBg}`}>
               {initials}
             </div>
             <div className="flex-1 min-w-0">
-              <p className="text-[13px] font-semibold text-slate-200 truncate leading-none">
+              <p className={`text-[13px] font-semibold truncate leading-none ${ls ? 'text-slate-700' : 'text-slate-200'}`}>
                 {firstName}
               </p>
               <span className={`text-[10px] font-medium mt-0.5 inline-block ${ROLE_COLOR[role].text}`}>
@@ -122,8 +134,8 @@ export default function FinanceiroLayout() {
             </div>
             <button
               onClick={handleLogout}
-              className="w-7 h-7 rounded-lg bg-white/5 flex items-center justify-center
-                text-slate-500 hover:text-red-400 hover:bg-red-400/10 transition-all shrink-0"
+              className={`w-7 h-7 rounded-lg flex items-center justify-center transition-all shrink-0
+                ${ls ? 'bg-slate-100 text-slate-400 hover:text-red-500 hover:bg-red-50' : 'bg-white/5 text-slate-500 hover:text-red-400 hover:bg-red-400/10'}`}
               title="Sair"
             >
               <LogOut size={13} />
@@ -137,26 +149,26 @@ export default function FinanceiroLayout() {
 
         {/* Mobile header */}
         <header
-          className="lg:hidden bg-[#0B1523] text-white px-4 py-3 sticky top-0 z-30
-            flex items-center gap-3"
-          style={{ boxShadow: '0 2px 20px rgba(0,0,0,0.4)' }}
+          className={`lg:hidden px-4 py-3 sticky top-0 z-30 flex items-center gap-3
+            ${ls ? 'bg-white border-b border-slate-200' : 'bg-[#0B1523] text-white'}`}
+          style={{ boxShadow: ls ? '0 1px 3px rgba(0,0,0,0.05)' : '0 2px 20px rgba(0,0,0,0.4)' }}
         >
           <button onClick={() => navigate('/')} className="shrink-0" title="Trocar módulo">
             <LogoTeg size={30} animated={false} />
           </button>
           <div className="flex-1 min-w-0">
             <div className="flex items-baseline gap-1.5">
-              <h1 className="text-sm font-black text-white leading-none">TEG+</h1>
-              <span className="text-[9px] text-emerald-400/70 font-semibold">Financeiro</span>
+              <h1 className={`text-sm font-black leading-none ${ls ? 'text-slate-800' : 'text-white'}`}>TEG+</h1>
+              <span className={`text-[9px] font-semibold ${ls ? 'text-emerald-500' : 'text-emerald-400/70'}`}>Financeiro</span>
             </div>
           </div>
           <div className={`w-8 h-8 rounded-full flex items-center justify-center
-            text-white text-xs font-extrabold ring-2 ring-white/10 ${avatarBg}`}>
+            text-white text-xs font-extrabold ring-2 ${ls ? 'ring-slate-200' : 'ring-white/10'} ${avatarBg}`}>
             {initials}
           </div>
           <button onClick={handleLogout}
-            className="w-7 h-7 rounded-lg bg-white/10 flex items-center justify-center
-              text-slate-400 hover:text-white hover:bg-white/20 transition-all shrink-0">
+            className={`w-7 h-7 rounded-lg flex items-center justify-center transition-all shrink-0
+              ${ls ? 'bg-slate-100 text-slate-400 hover:text-slate-600 hover:bg-slate-200' : 'bg-white/10 text-slate-400 hover:text-white hover:bg-white/20'}`}>
             <LogOut size={13} />
           </button>
         </header>
@@ -168,8 +180,11 @@ export default function FinanceiroLayout() {
         </main>
 
         {/* Mobile bottom nav */}
-        <nav className="lg:hidden fixed bottom-0 inset-x-0 z-40 glass-dark border-t border-white/[0.06]"
-          style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}>
+        <nav
+          className={`lg:hidden fixed bottom-0 inset-x-0 z-40 border-t
+            ${ls ? 'glass-light border-slate-200' : 'glass-dark border-white/[0.06]'}`}
+          style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+        >
           <div className="flex justify-around max-w-lg mx-auto px-1 py-1">
             {NAV.slice(0, 6).map(({ to, icon: Icon, label, end }) => (
               <NavLink key={to} to={to} end={end} className={bottomLinkClass}>

--- a/frontend/src/components/FrotasLayout.tsx
+++ b/frontend/src/components/FrotasLayout.tsx
@@ -4,6 +4,8 @@ import {
   Fuel, Radio, ChevronLeft, Menu, X,
 } from 'lucide-react'
 import { useState } from 'react'
+import { useTheme } from '../contexts/ThemeContext'
+import ThemeToggle from './ThemeToggle'
 
 const NAV = [
   { to: '/frotas',              label: 'Painel',          icon: LayoutDashboard, end: true },
@@ -14,91 +16,100 @@ const NAV = [
   { to: '/frotas/telemetria',   label: 'Telemetria',      icon: Radio },
 ]
 
-function NavItem({ to, label, icon: Icon, end }: { to: string; label: string; icon: React.ElementType; end?: boolean }) {
-  return (
-    <NavLink
-      to={to}
-      end={end}
-      className={({ isActive }) =>
-        [
-          'flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200 border',
-          isActive
-            ? 'bg-rose-500/15 text-rose-300 border-rose-500/25'
-            : 'text-slate-400 border-transparent hover:text-slate-200 hover:bg-white/5',
-        ].join(' ')
-      }
-    >
-      <Icon size={16} />
-      {label}
-    </NavLink>
-  )
-}
-
 export default function FrotasLayout() {
   const navigate = useNavigate()
+  const { isDark, isLightSidebar } = useTheme()
   const [open, setOpen] = useState(false)
+  const ls = isLightSidebar
+
+  function navLinkClass(isActive: boolean) {
+    const base = 'flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200 border'
+    if (isActive)
+      return `${base} ${ls ? 'bg-rose-50 text-rose-700 border-rose-200' : 'bg-rose-500/15 text-rose-300 border-rose-500/25'}`
+    return `${base} ${ls ? 'text-slate-500 border-transparent hover:text-slate-700 hover:bg-slate-50' : 'text-slate-400 border-transparent hover:text-slate-200 hover:bg-white/5'}`
+  }
 
   return (
-    <div className="flex h-screen bg-[#060D1B] overflow-hidden">
+    <div className={`flex h-screen overflow-hidden ${
+      ls ? 'bg-slate-50' : isDark ? 'bg-[#0c1222]' : 'bg-[#060D1B]'
+    }`}>
 
       {/* ── Desktop Sidebar ──────────────────────────────────── */}
-      <aside className="hidden md:flex flex-col w-56 shrink-0 border-r border-white/6 bg-white/[0.02] p-4 gap-2">
-
+      <aside className={`hidden md:flex flex-col w-56 shrink-0 p-4 gap-2
+        ${ls
+          ? 'bg-white border-r border-slate-200/80'
+          : 'border-r border-white/6 bg-white/[0.02]'
+        }`}
+      >
         {/* Module badge */}
         <button
           onClick={() => navigate('/')}
-          className="flex items-center gap-2.5 px-3 py-2.5 rounded-xl
-            bg-rose-500/10 border border-rose-500/25 mb-2
-            hover:bg-rose-500/15 transition-colors"
+          className={`flex items-center gap-2.5 px-3 py-2.5 rounded-xl mb-2 transition-colors border
+            ${ls
+              ? 'bg-rose-50 border-rose-200 hover:bg-rose-100'
+              : 'bg-rose-500/10 border-rose-500/25 hover:bg-rose-500/15'
+            }`}
         >
           <span className="text-lg leading-none">🚗</span>
           <div className="text-left">
-            <p className="text-[11px] font-bold text-rose-300 leading-none">Frotas</p>
-            <p className="text-[9px] text-rose-300/50 mt-0.5">Manutenção & Uso</p>
+            <p className={`text-[11px] font-bold leading-none ${ls ? 'text-rose-700' : 'text-rose-300'}`}>Frotas</p>
+            <p className={`text-[9px] mt-0.5 ${ls ? 'text-rose-500/60' : 'text-rose-300/50'}`}>Manutenção & Uso</p>
           </div>
-          <ChevronLeft size={12} className="ml-auto text-rose-300/50" />
+          <ChevronLeft size={12} className={`ml-auto ${ls ? 'text-rose-400' : 'text-rose-300/50'}`} />
         </button>
 
         {/* Nav */}
         <nav className="flex flex-col gap-1">
-          {NAV.map(n => <NavItem key={n.to} {...n} />)}
+          {NAV.map(n => (
+            <NavLink
+              key={n.to}
+              to={n.to}
+              end={n.end}
+              className={({ isActive }) => navLinkClass(isActive)}
+            >
+              <n.icon size={16} />
+              {n.label}
+            </NavLink>
+          ))}
         </nav>
 
-        {/* Footer */}
-        <div className="mt-auto pt-4 border-t border-white/5">
-          <p className="text-[10px] text-slate-600 text-center">TEG+ ERP · Frotas</p>
+        {/* Theme toggle + Footer */}
+        <div className="mt-auto space-y-3">
+          <ThemeToggle variant={ls ? 'light' : 'dark'} compact />
+          <div className={`pt-4 border-t ${ls ? 'border-slate-100' : 'border-white/5'}`}>
+            <p className={`text-[10px] text-center ${ls ? 'text-slate-400' : 'text-slate-600'}`}>TEG+ ERP · Frotas</p>
+          </div>
         </div>
       </aside>
 
       {/* ── Mobile Header ────────────────────────────────────── */}
       <div className="flex flex-col flex-1 min-w-0">
-        <header className="md:hidden flex items-center justify-between px-4 py-3 border-b border-white/6 bg-white/[0.02]">
+        <header className={`md:hidden flex items-center justify-between px-4 py-3 border-b
+          ${ls
+            ? 'bg-white border-slate-200'
+            : 'border-white/6 bg-white/[0.02]'
+          }`}
+        >
           <div className="flex items-center gap-2">
             <span className="text-base">🚗</span>
-            <span className="text-xs font-semibold text-rose-400/70 uppercase tracking-widest">Frotas</span>
+            <span className={`text-xs font-semibold uppercase tracking-widest ${ls ? 'text-rose-500' : 'text-rose-400/70'}`}>Frotas</span>
           </div>
-          <button onClick={() => setOpen(o => !o)} className="text-slate-400 hover:text-white">
+          <button onClick={() => setOpen(o => !o)} className={`${ls ? 'text-slate-500 hover:text-slate-700' : 'text-slate-400 hover:text-white'}`}>
             {open ? <X size={20} /> : <Menu size={20} />}
           </button>
         </header>
 
         {/* Mobile drawer */}
         {open && (
-          <nav className="md:hidden flex flex-col gap-1 p-4 border-b border-white/6 bg-white/[0.03]">
+          <nav className={`md:hidden flex flex-col gap-1 p-4 border-b
+            ${ls ? 'bg-white border-slate-200' : 'border-white/6 bg-white/[0.03]'}`}>
             {NAV.map(n => (
               <NavLink
                 key={n.to}
                 to={n.to}
                 end={n.end}
                 onClick={() => setOpen(false)}
-                className={({ isActive }) =>
-                  [
-                    'flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all border',
-                    isActive
-                      ? 'bg-rose-500/15 text-rose-300 border-rose-500/25'
-                      : 'text-slate-400 border-transparent hover:text-slate-200 hover:bg-white/5',
-                  ].join(' ')
-                }
+                className={({ isActive }) => navLinkClass(isActive)}
               >
                 <n.icon size={16} />
                 {n.label}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -4,7 +4,9 @@ import {
   User, LogOut, Shield, LayoutGrid, Truck,
 } from 'lucide-react'
 import { useAuth, ROLE_LABEL, ROLE_COLOR } from '../contexts/AuthContext'
+import { useTheme } from '../contexts/ThemeContext'
 import LogoTeg from './LogoTeg'
+import ThemeToggle from './ThemeToggle'
 
 // ── Navigation items ───────────────────────────────────────────────────────────
 const NAV = [
@@ -37,12 +39,16 @@ function getInitials(name: string): string {
 // ── Component ──────────────────────────────────────────────────────────────────
 export default function Layout() {
   const { perfil, isAdmin, signOut, role } = useAuth()
+  const { isDark, isLightSidebar } = useTheme()
   const navigate = useNavigate()
 
   const nome      = perfil?.nome ?? 'Usuário'
   const initials  = getInitials(nome)
   const avatarBg  = getAvatarColor(nome)
   const firstName = nome.split(' ')[0]
+
+  // Light sidebar shorthand
+  const ls = isLightSidebar
 
   async function handleLogout() {
     await signOut()
@@ -53,54 +59,57 @@ export default function Layout() {
   function sidebarLinkClass({ isActive }: { isActive: boolean }) {
     const base = 'flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-semibold transition-all duration-150 border'
     if (isActive)
-      return `${base} bg-teal-500/15 text-teal-300 border-teal-500/25`
-    return `${base} text-slate-400 hover:text-slate-100 hover:bg-white/6 border-transparent`
+      return `${base} ${ls ? 'bg-teal-50 text-teal-700 border-teal-200' : 'bg-teal-500/15 text-teal-300 border-teal-500/25'}`
+    return `${base} ${ls ? 'text-slate-500 hover:text-slate-800 hover:bg-slate-50 border-transparent' : 'text-slate-400 hover:text-slate-100 hover:bg-white/6 border-transparent'}`
   }
 
   function bottomLinkClass({ isActive }: { isActive: boolean }) {
     const base = 'flex flex-col items-center py-2 px-2.5 rounded-xl text-[10px] font-semibold transition-all duration-150 min-w-[46px]'
     if (isActive)
-      return `${base} text-teal-400 bg-teal-400/10`
-    return `${base} text-slate-500 hover:text-slate-300`
+      return `${base} ${ls ? 'text-teal-600 bg-teal-50' : 'text-teal-400 bg-teal-400/10'}`
+    return `${base} ${ls ? 'text-slate-400 hover:text-slate-600' : 'text-slate-500 hover:text-slate-300'}`
   }
 
   return (
-    <div className="min-h-screen bg-slate-100">
+    <div className={`min-h-screen ${isDark ? 'bg-[#0c1222]' : ls ? 'bg-slate-50' : 'bg-slate-100'}`}>
 
       {/* ══════════════════════════════════════════════════════════════
            DESKTOP SIDEBAR  (hidden on mobile, visible ≥ lg)
       ══════════════════════════════════════════════════════════════ */}
       <aside
-        className="hidden lg:flex flex-col fixed left-0 top-0 h-full w-64 bg-[#0B1523] z-40"
-        style={{ boxShadow: '4px 0 24px rgba(0,0,0,0.4)' }}
+        className={`hidden lg:flex flex-col fixed left-0 top-0 h-full w-64 z-40
+          ${ls ? 'bg-white border-r border-slate-200/80' : 'bg-[#0B1523]'}`}
+        style={{ boxShadow: ls ? '1px 0 0 rgba(0,0,0,0.05)' : '4px 0 24px rgba(0,0,0,0.4)' }}
       >
         {/* ── Top: brand + module badge ───────────────────────── */}
-        <div className="px-4 pt-5 pb-4 border-b border-white/[0.06]">
+        <div className={`px-4 pt-5 pb-4 border-b ${ls ? 'border-slate-100' : 'border-white/[0.06]'}`}>
           {/* Logo + wordmark */}
           <div className="flex items-center gap-3 mb-4">
             <LogoTeg size={38} animated={false} />
             <div>
-              <p className="text-white font-black text-lg tracking-tight leading-none">TEG+</p>
-              <p className="text-[10px] text-slate-500 font-medium mt-0.5">ERP Sistema</p>
+              <p className={`font-black text-lg tracking-tight leading-none ${ls ? 'text-slate-800' : 'text-white'}`}>TEG+</p>
+              <p className={`text-[10px] font-medium mt-0.5 ${ls ? 'text-slate-400' : 'text-slate-500'}`}>ERP Sistema</p>
             </div>
           </div>
 
           {/* Active module badge — click to go back to module selector */}
           <button
             onClick={() => navigate('/')}
-            className="w-full flex items-center gap-2.5 bg-teal-500/10 border border-teal-500/25
-              rounded-xl px-3 py-2.5 hover:bg-teal-500/18 hover:border-teal-500/40
-              transition-all duration-150 group"
+            className={`w-full flex items-center gap-2.5 rounded-xl px-3 py-2.5 transition-all duration-150 group border
+              ${ls
+                ? 'bg-teal-50 border-teal-200 hover:bg-teal-100 hover:border-teal-300'
+                : 'bg-teal-500/10 border-teal-500/25 hover:bg-teal-500/18 hover:border-teal-500/40'
+              }`}
             title="Trocar módulo"
           >
             <span className="text-lg leading-none">🛒</span>
             <div className="flex-1 text-left">
-              <p className="text-xs font-bold text-teal-300 leading-none">Compras</p>
-              <p className="text-[9px] text-teal-500/60 mt-0.5">Módulo ativo</p>
+              <p className={`text-xs font-bold leading-none ${ls ? 'text-teal-700' : 'text-teal-300'}`}>Compras</p>
+              <p className={`text-[9px] mt-0.5 ${ls ? 'text-teal-500/60' : 'text-teal-500/60'}`}>Módulo ativo</p>
             </div>
             <LayoutGrid
               size={13}
-              className="text-teal-500/50 group-hover:text-teal-400 transition-colors shrink-0"
+              className={`transition-colors shrink-0 ${ls ? 'text-teal-400 group-hover:text-teal-500' : 'text-teal-500/50 group-hover:text-teal-400'}`}
             />
           </button>
         </div>
@@ -117,15 +126,15 @@ export default function Layout() {
           {/* Admin link */}
           {isAdmin && (
             <>
-              <div className="h-px bg-white/[0.05] mx-2 my-2" />
+              <div className={`h-px mx-2 my-2 ${ls ? 'bg-slate-100' : 'bg-white/[0.05]'}`} />
               <NavLink
                 to="/admin/usuarios"
                 className={({ isActive }) =>
                   `flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-semibold
                   transition-all duration-150 border
                   ${isActive
-                    ? 'bg-amber-500/12 text-amber-300 border-amber-500/25'
-                    : 'text-slate-500 hover:text-slate-300 hover:bg-white/5 border-transparent'
+                    ? ls ? 'bg-amber-50 text-amber-700 border-amber-200' : 'bg-amber-500/12 text-amber-300 border-amber-500/25'
+                    : ls ? 'text-slate-500 hover:text-slate-700 hover:bg-slate-50 border-transparent' : 'text-slate-500 hover:text-slate-300 hover:bg-white/5 border-transparent'
                   }`
                 }
               >
@@ -136,22 +145,27 @@ export default function Layout() {
           )}
         </nav>
 
+        {/* ── Theme toggle ──────────────────────────────────── */}
+        <div className={`px-3 py-2 border-t ${ls ? 'border-slate-100' : 'border-white/[0.06]'}`}>
+          <ThemeToggle variant={ls ? 'light' : 'dark'} />
+        </div>
+
         {/* ── Bottom: user card + logout ─────────────────────── */}
-        <div className="px-3 pb-4 pt-2 border-t border-white/[0.06]">
+        <div className={`px-3 pb-4 pt-2 border-t ${ls ? 'border-slate-100' : 'border-white/[0.06]'}`}>
           {/* User info */}
-          <div className="flex items-center gap-2.5 px-2 py-2.5 rounded-xl hover:bg-white/4 transition-colors">
+          <div className={`flex items-center gap-2.5 px-2 py-2.5 rounded-xl transition-colors ${ls ? 'hover:bg-slate-50' : 'hover:bg-white/4'}`}>
             <button
               onClick={() => navigate('/perfil')}
               className={`w-9 h-9 rounded-full flex items-center justify-center
-                text-white text-xs font-extrabold shrink-0 ring-2 ring-white/10
-                transition-transform active:scale-90 ${avatarBg}`}
+                text-white text-xs font-extrabold shrink-0 ring-2
+                transition-transform active:scale-90 ${avatarBg} ${ls ? 'ring-slate-200' : 'ring-white/10'}`}
               title="Ver perfil"
             >
               {initials}
             </button>
 
             <div className="flex-1 min-w-0">
-              <p className="text-[13px] font-semibold text-slate-200 truncate leading-none">
+              <p className={`text-[13px] font-semibold truncate leading-none ${ls ? 'text-slate-700' : 'text-slate-200'}`}>
                 {firstName}
               </p>
               <span
@@ -164,8 +178,8 @@ export default function Layout() {
 
             <button
               onClick={handleLogout}
-              className="w-7 h-7 rounded-lg bg-white/5 flex items-center justify-center
-                text-slate-500 hover:text-red-400 hover:bg-red-400/10 transition-all shrink-0"
+              className={`w-7 h-7 rounded-lg flex items-center justify-center transition-all shrink-0
+                ${ls ? 'bg-slate-100 text-slate-400 hover:text-red-500 hover:bg-red-50' : 'bg-white/5 text-slate-500 hover:text-red-400 hover:bg-red-400/10'}`}
               title="Sair"
             >
               <LogOut size={13} />
@@ -181,9 +195,9 @@ export default function Layout() {
 
         {/* ── Mobile-only header ──────────────────────────────── */}
         <header
-          className="lg:hidden bg-[#0B1523] text-white px-4 py-3 sticky top-0 z-30
-            flex items-center gap-3"
-          style={{ boxShadow: '0 2px 20px rgba(0,0,0,0.4)' }}
+          className={`lg:hidden px-4 py-3 sticky top-0 z-30 flex items-center gap-3
+            ${ls ? 'bg-white border-b border-slate-200' : 'bg-[#0B1523] text-white'}`}
+          style={{ boxShadow: ls ? '0 1px 3px rgba(0,0,0,0.05)' : '0 2px 20px rgba(0,0,0,0.4)' }}
         >
           {/* Logo */}
           <button onClick={() => navigate('/')} className="shrink-0" title="Trocar módulo">
@@ -193,8 +207,8 @@ export default function Layout() {
           {/* Brand */}
           <div className="flex-1 min-w-0">
             <div className="flex items-baseline gap-1.5">
-              <h1 className="text-sm font-black text-white leading-none">TEG+</h1>
-              <span className="text-[9px] text-teal-400/70 font-semibold">Compras</span>
+              <h1 className={`text-sm font-black leading-none ${ls ? 'text-slate-800' : 'text-white'}`}>TEG+</h1>
+              <span className={`text-[9px] font-semibold ${ls ? 'text-teal-500' : 'text-teal-400/70'}`}>Compras</span>
             </div>
           </div>
 
@@ -202,8 +216,8 @@ export default function Layout() {
           <button
             onClick={() => navigate('/perfil')}
             className={`w-8 h-8 rounded-full flex items-center justify-center
-              text-white text-xs font-extrabold ring-2 ring-white/10
-              shrink-0 transition-transform active:scale-90 ${avatarBg}`}
+              text-white text-xs font-extrabold ring-2
+              shrink-0 transition-transform active:scale-90 ${avatarBg} ${ls ? 'ring-slate-200' : 'ring-white/10'}`}
             title={`${nome} · ${ROLE_LABEL[role]}`}
           >
             {initials}
@@ -212,8 +226,8 @@ export default function Layout() {
           {/* Logout */}
           <button
             onClick={handleLogout}
-            className="w-7 h-7 rounded-lg bg-white/10 flex items-center justify-center
-              text-slate-400 hover:text-white hover:bg-white/20 transition-all shrink-0"
+            className={`w-7 h-7 rounded-lg flex items-center justify-center transition-all shrink-0
+              ${ls ? 'bg-slate-100 text-slate-400 hover:text-slate-600 hover:bg-slate-200' : 'bg-white/10 text-slate-400 hover:text-white hover:bg-white/20'}`}
             title="Sair"
           >
             <LogOut size={13} />
@@ -229,7 +243,8 @@ export default function Layout() {
 
         {/* ── Mobile bottom nav (hidden on desktop) ────────────── */}
         <nav
-          className="lg:hidden fixed bottom-0 inset-x-0 z-40 glass-dark border-t border-white/[0.06]"
+          className={`lg:hidden fixed bottom-0 inset-x-0 z-40 border-t
+            ${ls ? 'glass-light border-slate-200' : 'glass-dark border-white/[0.06]'}`}
           style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
         >
           <div className="flex justify-around max-w-lg mx-auto px-1 py-1">

--- a/frontend/src/components/LogisticaLayout.tsx
+++ b/frontend/src/components/LogisticaLayout.tsx
@@ -4,7 +4,9 @@ import {
   Truck, CheckCircle2, Building2, LogOut, LayoutGrid,
 } from 'lucide-react'
 import { useAuth, ROLE_LABEL, ROLE_COLOR } from '../contexts/AuthContext'
+import { useTheme } from '../contexts/ThemeContext'
 import LogoTeg from './LogoTeg'
+import ThemeToggle from './ThemeToggle'
 
 const NAV = [
   { to: '/logistica',                 icon: LayoutDashboard, label: 'Painel',          end: true  },
@@ -34,12 +36,14 @@ function getInitials(name: string): string {
 
 export default function LogisticaLayout() {
   const { perfil, signOut, role } = useAuth()
+  const { isDark, isLightSidebar } = useTheme()
   const navigate = useNavigate()
 
   const nome      = perfil?.nome ?? 'Usuário'
   const initials  = getInitials(nome)
   const avatarBg  = getAvatarColor(nome)
   const firstName = nome.split(' ')[0]
+  const ls = isLightSidebar
 
   async function handleLogout() {
     await signOut()
@@ -49,48 +53,51 @@ export default function LogisticaLayout() {
   function sidebarLinkClass({ isActive }: { isActive: boolean }) {
     const base = 'flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-semibold transition-all duration-150 border'
     if (isActive)
-      return `${base} bg-orange-500/15 text-orange-300 border-orange-500/25`
-    return `${base} text-slate-400 hover:text-slate-100 hover:bg-white/6 border-transparent`
+      return `${base} ${ls ? 'bg-orange-50 text-orange-700 border-orange-200' : 'bg-orange-500/15 text-orange-300 border-orange-500/25'}`
+    return `${base} ${ls ? 'text-slate-500 hover:text-slate-800 hover:bg-slate-50 border-transparent' : 'text-slate-400 hover:text-slate-100 hover:bg-white/6 border-transparent'}`
   }
 
   function bottomLinkClass({ isActive }: { isActive: boolean }) {
     const base = 'flex flex-col items-center py-2 px-1.5 rounded-xl text-[9px] font-semibold transition-all duration-150 min-w-[40px]'
     if (isActive)
-      return `${base} text-orange-400 bg-orange-400/10`
-    return `${base} text-slate-500 hover:text-slate-300`
+      return `${base} ${ls ? 'text-orange-600 bg-orange-50' : 'text-orange-400 bg-orange-400/10'}`
+    return `${base} ${ls ? 'text-slate-400 hover:text-slate-600' : 'text-slate-500 hover:text-slate-300'}`
   }
 
   return (
-    <div className="min-h-screen bg-slate-100">
+    <div className={`min-h-screen ${isDark ? 'bg-[#0c1222]' : ls ? 'bg-slate-50' : 'bg-slate-100'}`}>
 
       {/* ── DESKTOP SIDEBAR ────────────────────────────────────── */}
       <aside
-        className="hidden lg:flex flex-col fixed left-0 top-0 h-full w-64 bg-[#0B1523] z-40"
-        style={{ boxShadow: '4px 0 24px rgba(0,0,0,0.4)' }}
+        className={`hidden lg:flex flex-col fixed left-0 top-0 h-full w-64 z-40
+          ${ls ? 'bg-white border-r border-slate-200/80' : 'bg-[#0B1523]'}`}
+        style={{ boxShadow: ls ? '1px 0 0 rgba(0,0,0,0.05)' : '4px 0 24px rgba(0,0,0,0.4)' }}
       >
-        <div className="px-4 pt-5 pb-4 border-b border-white/[0.06]">
+        <div className={`px-4 pt-5 pb-4 border-b ${ls ? 'border-slate-100' : 'border-white/[0.06]'}`}>
           <div className="flex items-center gap-3 mb-4">
             <LogoTeg size={38} animated={false} />
             <div>
-              <p className="text-white font-black text-lg tracking-tight leading-none">TEG+</p>
-              <p className="text-[10px] text-slate-500 font-medium mt-0.5">ERP Sistema</p>
+              <p className={`font-black text-lg tracking-tight leading-none ${ls ? 'text-slate-800' : 'text-white'}`}>TEG+</p>
+              <p className={`text-[10px] font-medium mt-0.5 ${ls ? 'text-slate-400' : 'text-slate-500'}`}>ERP Sistema</p>
             </div>
           </div>
           <button
             onClick={() => navigate('/')}
-            className="w-full flex items-center gap-2.5 bg-orange-500/10 border border-orange-500/25
-              rounded-xl px-3 py-2.5 hover:bg-orange-500/18 hover:border-orange-500/40
-              transition-all duration-150 group"
+            className={`w-full flex items-center gap-2.5 rounded-xl px-3 py-2.5 transition-all duration-150 group border
+              ${ls
+                ? 'bg-orange-50 border-orange-200 hover:bg-orange-100 hover:border-orange-300'
+                : 'bg-orange-500/10 border-orange-500/25 hover:bg-orange-500/18 hover:border-orange-500/40'
+              }`}
             title="Trocar módulo"
           >
             <span className="text-lg leading-none">🚛</span>
             <div className="flex-1 text-left">
-              <p className="text-xs font-bold text-orange-300 leading-none">Logística</p>
-              <p className="text-[9px] text-orange-500/60 mt-0.5">Módulo ativo</p>
+              <p className={`text-xs font-bold leading-none ${ls ? 'text-orange-700' : 'text-orange-300'}`}>Logística</p>
+              <p className={`text-[9px] mt-0.5 ${ls ? 'text-orange-500/60' : 'text-orange-500/60'}`}>Módulo ativo</p>
             </div>
             <LayoutGrid
               size={13}
-              className="text-orange-500/50 group-hover:text-orange-400 transition-colors shrink-0"
+              className={`transition-colors shrink-0 ${ls ? 'text-orange-400 group-hover:text-orange-500' : 'text-orange-500/50 group-hover:text-orange-400'}`}
             />
           </button>
         </div>
@@ -104,14 +111,19 @@ export default function LogisticaLayout() {
           ))}
         </nav>
 
-        <div className="px-3 pb-4 pt-2 border-t border-white/[0.06]">
-          <div className="flex items-center gap-2.5 px-2 py-2.5 rounded-xl hover:bg-white/4 transition-colors">
+        {/* Theme toggle */}
+        <div className={`px-3 py-2 border-t ${ls ? 'border-slate-100' : 'border-white/[0.06]'}`}>
+          <ThemeToggle variant={ls ? 'light' : 'dark'} />
+        </div>
+
+        <div className={`px-3 pb-4 pt-2 border-t ${ls ? 'border-slate-100' : 'border-white/[0.06]'}`}>
+          <div className={`flex items-center gap-2.5 px-2 py-2.5 rounded-xl transition-colors ${ls ? 'hover:bg-slate-50' : 'hover:bg-white/4'}`}>
             <div className={`w-9 h-9 rounded-full flex items-center justify-center
-              text-white text-xs font-extrabold shrink-0 ring-2 ring-white/10 ${avatarBg}`}>
+              text-white text-xs font-extrabold shrink-0 ring-2 ${ls ? 'ring-slate-200' : 'ring-white/10'} ${avatarBg}`}>
               {initials}
             </div>
             <div className="flex-1 min-w-0">
-              <p className="text-[13px] font-semibold text-slate-200 truncate leading-none">
+              <p className={`text-[13px] font-semibold truncate leading-none ${ls ? 'text-slate-700' : 'text-slate-200'}`}>
                 {firstName}
               </p>
               <span className={`text-[10px] font-medium mt-0.5 inline-block ${ROLE_COLOR[role].text}`}>
@@ -120,8 +132,8 @@ export default function LogisticaLayout() {
             </div>
             <button
               onClick={handleLogout}
-              className="w-7 h-7 rounded-lg bg-white/5 flex items-center justify-center
-                text-slate-500 hover:text-red-400 hover:bg-red-400/10 transition-all shrink-0"
+              className={`w-7 h-7 rounded-lg flex items-center justify-center transition-all shrink-0
+                ${ls ? 'bg-slate-100 text-slate-400 hover:text-red-500 hover:bg-red-50' : 'bg-white/5 text-slate-500 hover:text-red-400 hover:bg-red-400/10'}`}
               title="Sair"
             >
               <LogOut size={13} />
@@ -135,26 +147,26 @@ export default function LogisticaLayout() {
 
         {/* Mobile header */}
         <header
-          className="lg:hidden bg-[#0B1523] text-white px-4 py-3 sticky top-0 z-30
-            flex items-center gap-3"
-          style={{ boxShadow: '0 2px 20px rgba(0,0,0,0.4)' }}
+          className={`lg:hidden px-4 py-3 sticky top-0 z-30 flex items-center gap-3
+            ${ls ? 'bg-white border-b border-slate-200' : 'bg-[#0B1523] text-white'}`}
+          style={{ boxShadow: ls ? '0 1px 3px rgba(0,0,0,0.05)' : '0 2px 20px rgba(0,0,0,0.4)' }}
         >
           <button onClick={() => navigate('/')} className="shrink-0" title="Trocar módulo">
             <LogoTeg size={30} animated={false} />
           </button>
           <div className="flex-1 min-w-0">
             <div className="flex items-baseline gap-1.5">
-              <h1 className="text-sm font-black text-white leading-none">TEG+</h1>
-              <span className="text-[9px] text-orange-400/70 font-semibold">Logística</span>
+              <h1 className={`text-sm font-black leading-none ${ls ? 'text-slate-800' : 'text-white'}`}>TEG+</h1>
+              <span className={`text-[9px] font-semibold ${ls ? 'text-orange-500' : 'text-orange-400/70'}`}>Logística</span>
             </div>
           </div>
           <div className={`w-8 h-8 rounded-full flex items-center justify-center
-            text-white text-xs font-extrabold ring-2 ring-white/10 ${avatarBg}`}>
+            text-white text-xs font-extrabold ring-2 ${ls ? 'ring-slate-200' : 'ring-white/10'} ${avatarBg}`}>
             {initials}
           </div>
           <button onClick={handleLogout}
-            className="w-7 h-7 rounded-lg bg-white/10 flex items-center justify-center
-              text-slate-400 hover:text-white hover:bg-white/20 transition-all shrink-0">
+            className={`w-7 h-7 rounded-lg flex items-center justify-center transition-all shrink-0
+              ${ls ? 'bg-slate-100 text-slate-400 hover:text-slate-600 hover:bg-slate-200' : 'bg-white/10 text-slate-400 hover:text-white hover:bg-white/20'}`}>
             <LogOut size={13} />
           </button>
         </header>
@@ -166,8 +178,11 @@ export default function LogisticaLayout() {
         </main>
 
         {/* Mobile bottom nav */}
-        <nav className="lg:hidden fixed bottom-0 inset-x-0 z-40 glass-dark border-t border-white/[0.06]"
-          style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}>
+        <nav
+          className={`lg:hidden fixed bottom-0 inset-x-0 z-40 border-t
+            ${ls ? 'glass-light border-slate-200' : 'glass-dark border-white/[0.06]'}`}
+          style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+        >
           <div className="flex justify-around max-w-lg mx-auto px-1 py-1">
             {NAV.slice(0, 6).map(({ to, icon: Icon, label, end }) => (
               <NavLink key={to} to={to} end={end} className={bottomLinkClass}>

--- a/frontend/src/components/RHLayout.tsx
+++ b/frontend/src/components/RHLayout.tsx
@@ -5,6 +5,8 @@ import { NavLink, Outlet, useNavigate } from 'react-router-dom'
 import { LayoutDashboard, ImagePlay, ChevronLeft, Menu, X, Shield } from 'lucide-react'
 import { useState } from 'react'
 import { useAuth } from '../contexts/AuthContext'
+import { useTheme } from '../contexts/ThemeContext'
+import ThemeToggle from './ThemeToggle'
 
 interface NavEntry {
   to: string
@@ -19,96 +21,105 @@ const NAV: NavEntry[] = [
   { to: '/rh/mural', label: 'Mural de Recados', icon: ImagePlay, adminOnly: true },
 ]
 
-function NavItem({ to, label, icon: Icon, end, adminOnly }: NavEntry) {
-  return (
-    <NavLink
-      to={to}
-      end={end}
-      className={({ isActive }) =>
-        [
-          'flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200 border',
-          isActive
-            ? 'bg-violet-500/15 text-violet-300 border-violet-500/25'
-            : 'text-slate-400 border-transparent hover:text-slate-200 hover:bg-white/5',
-        ].join(' ')
-      }
-    >
-      <Icon size={16} />
-      <span className="flex-1">{label}</span>
-      {adminOnly && (
-        <Shield size={10} className="text-violet-400/50 shrink-0" />
-      )}
-    </NavLink>
-  )
-}
-
 export default function RHLayout() {
   const navigate      = useNavigate()
   const { isAdmin }   = useAuth()
+  const { isDark, isLightSidebar } = useTheme()
   const [open, setOpen] = useState(false)
+  const ls = isLightSidebar
 
   const visibleNav = NAV.filter(n => !n.adminOnly || isAdmin)
 
+  function navLinkClass(isActive: boolean) {
+    const base = 'flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200 border'
+    if (isActive)
+      return `${base} ${ls ? 'bg-violet-50 text-violet-700 border-violet-200' : 'bg-violet-500/15 text-violet-300 border-violet-500/25'}`
+    return `${base} ${ls ? 'text-slate-500 border-transparent hover:text-slate-700 hover:bg-slate-50' : 'text-slate-400 border-transparent hover:text-slate-200 hover:bg-white/5'}`
+  }
+
   return (
-    <div className="flex h-screen bg-[#060D1B] overflow-hidden">
+    <div className={`flex h-screen overflow-hidden ${
+      ls ? 'bg-slate-50' : isDark ? 'bg-[#0c1222]' : 'bg-[#060D1B]'
+    }`}>
 
       {/* ── Desktop Sidebar ──────────────────────────────────── */}
-      <aside className="hidden md:flex flex-col w-56 shrink-0 border-r border-white/6 bg-white/[0.02] p-4 gap-2">
-
+      <aside className={`hidden md:flex flex-col w-56 shrink-0 p-4 gap-2
+        ${ls
+          ? 'bg-white border-r border-slate-200/80'
+          : 'border-r border-white/6 bg-white/[0.02]'
+        }`}
+      >
         {/* Module badge */}
         <button
           onClick={() => navigate('/')}
-          className="flex items-center gap-2.5 px-3 py-2.5 rounded-xl
-            bg-violet-500/10 border border-violet-500/25 mb-2
-            hover:bg-violet-500/15 transition-colors"
+          className={`flex items-center gap-2.5 px-3 py-2.5 rounded-xl mb-2 transition-colors border
+            ${ls
+              ? 'bg-violet-50 border-violet-200 hover:bg-violet-100'
+              : 'bg-violet-500/10 border-violet-500/25 hover:bg-violet-500/15'
+            }`}
         >
           <span className="text-lg leading-none">👥</span>
           <div className="text-left">
-            <p className="text-[11px] font-bold text-violet-300 leading-none">Recursos Humanos</p>
-            <p className="text-[9px] text-violet-300/50 mt-0.5">Pessoas & Organização</p>
+            <p className={`text-[11px] font-bold leading-none ${ls ? 'text-violet-700' : 'text-violet-300'}`}>Recursos Humanos</p>
+            <p className={`text-[9px] mt-0.5 ${ls ? 'text-violet-500/60' : 'text-violet-300/50'}`}>Pessoas & Organização</p>
           </div>
-          <ChevronLeft size={12} className="ml-auto text-violet-300/50" />
+          <ChevronLeft size={12} className={`ml-auto ${ls ? 'text-violet-400' : 'text-violet-300/50'}`} />
         </button>
 
         {/* Nav */}
         <nav className="flex flex-col gap-1">
-          {visibleNav.map(n => <NavItem key={n.to} {...n} />)}
+          {visibleNav.map(n => (
+            <NavLink
+              key={n.to}
+              to={n.to}
+              end={n.end}
+              className={({ isActive }) => navLinkClass(isActive)}
+            >
+              <n.icon size={16} />
+              <span className="flex-1">{n.label}</span>
+              {n.adminOnly && (
+                <Shield size={10} className={`shrink-0 ${ls ? 'text-violet-300' : 'text-violet-400/50'}`} />
+              )}
+            </NavLink>
+          ))}
         </nav>
 
-        {/* Footer */}
-        <div className="mt-auto pt-4 border-t border-white/5">
-          <p className="text-[10px] text-slate-600 text-center">TEG+ ERP · RH</p>
+        {/* Theme toggle + Footer */}
+        <div className="mt-auto space-y-3">
+          <ThemeToggle variant={ls ? 'light' : 'dark'} compact />
+          <div className={`pt-4 border-t ${ls ? 'border-slate-100' : 'border-white/5'}`}>
+            <p className={`text-[10px] text-center ${ls ? 'text-slate-400' : 'text-slate-600'}`}>TEG+ ERP · RH</p>
+          </div>
         </div>
       </aside>
 
       {/* ── Mobile ───────────────────────────────────────────── */}
       <div className="flex flex-col flex-1 min-w-0">
-        <header className="md:hidden flex items-center justify-between px-4 py-3 border-b border-white/6 bg-white/[0.02]">
+        <header className={`md:hidden flex items-center justify-between px-4 py-3 border-b
+          ${ls
+            ? 'bg-white border-slate-200'
+            : 'border-white/6 bg-white/[0.02]'
+          }`}
+        >
           <div className="flex items-center gap-2">
             <span className="text-base">👥</span>
-            <span className="text-xs font-semibold text-violet-400/70 uppercase tracking-widest">RH</span>
+            <span className={`text-xs font-semibold uppercase tracking-widest ${ls ? 'text-violet-500' : 'text-violet-400/70'}`}>RH</span>
           </div>
-          <button onClick={() => setOpen(o => !o)} className="text-slate-400 hover:text-white">
+          <button onClick={() => setOpen(o => !o)} className={`${ls ? 'text-slate-500 hover:text-slate-700' : 'text-slate-400 hover:text-white'}`}>
             {open ? <X size={20} /> : <Menu size={20} />}
           </button>
         </header>
 
         {open && (
-          <nav className="md:hidden flex flex-col gap-1 p-4 border-b border-white/6 bg-white/[0.03]">
+          <nav className={`md:hidden flex flex-col gap-1 p-4 border-b
+            ${ls ? 'bg-white border-slate-200' : 'border-white/6 bg-white/[0.03]'}`}>
             {visibleNav.map(n => (
               <NavLink
                 key={n.to}
                 to={n.to}
                 end={n.end}
                 onClick={() => setOpen(false)}
-                className={({ isActive }) =>
-                  [
-                    'flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all border',
-                    isActive
-                      ? 'bg-violet-500/15 text-violet-300 border-violet-500/25'
-                      : 'text-slate-400 border-transparent hover:text-slate-200 hover:bg-white/5',
-                  ].join(' ')
-                }
+                className={({ isActive }) => navLinkClass(isActive)}
               >
                 <n.icon size={16} />
                 {n.label}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,55 @@
+import { Sun, Moon, Monitor } from 'lucide-react'
+import { useTheme, type Theme } from '../contexts/ThemeContext'
+
+const OPTIONS: { value: Theme; icon: typeof Sun; label: string }[] = [
+  { value: 'original', icon: Monitor, label: 'Original' },
+  { value: 'dark',     icon: Moon,    label: 'Dark' },
+  { value: 'light',    icon: Sun,     label: 'Light' },
+]
+
+interface Props {
+  /** Visual variant that adapts to sidebar context */
+  variant?: 'dark' | 'light'
+  compact?: boolean
+}
+
+export default function ThemeToggle({ variant = 'dark', compact = false }: Props) {
+  const { theme, setTheme } = useTheme()
+  const isLight = variant === 'light'
+
+  return (
+    <div
+      className={[
+        'flex items-center gap-0.5 p-0.5 rounded-lg border',
+        isLight
+          ? 'bg-slate-100 border-slate-200'
+          : 'bg-white/5 border-white/[0.06]',
+      ].join(' ')}
+    >
+      {OPTIONS.map(({ value, icon: Icon, label }) => {
+        const active = theme === value
+        return (
+          <button
+            key={value}
+            onClick={() => setTheme(value)}
+            className={[
+              'flex items-center gap-1.5 rounded-md text-[10px] font-semibold transition-all duration-150',
+              compact ? 'px-1.5 py-1.5' : 'px-2 py-1.5',
+              active
+                ? isLight
+                  ? 'bg-white text-slate-700 shadow-sm'
+                  : 'bg-white/10 text-white shadow-sm'
+                : isLight
+                  ? 'text-slate-400 hover:text-slate-600'
+                  : 'text-slate-500 hover:text-slate-300',
+            ].join(' ')}
+            title={label}
+          >
+            <Icon size={12} />
+            {!compact && <span>{label}</span>}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,72 @@
+import {
+  createContext, useContext, useState, useEffect, useCallback, ReactNode,
+} from 'react'
+
+// ── Types ───────────────────────────────────────────────────────────────────────
+
+export type Theme = 'original' | 'dark' | 'light'
+
+interface ThemeContextType {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+  /** true when dark theme is active (content area should be dark) */
+  isDark: boolean
+  /** true when light theme is active (sidebar should be light) */
+  isLightSidebar: boolean
+}
+
+// ── Context ─────────────────────────────────────────────────────────────────────
+
+const ThemeContext = createContext<ThemeContextType | null>(null)
+
+const STORAGE_KEY = 'teg-theme'
+
+// ── Provider ────────────────────────────────────────────────────────────────────
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY) as Theme | null
+      if (stored && ['original', 'dark', 'light'].includes(stored)) return stored
+    } catch { /* SSR / restricted storage */ }
+    return 'original'
+  })
+
+  const setTheme = useCallback((t: Theme) => {
+    setThemeState(t)
+    try { localStorage.setItem(STORAGE_KEY, t) } catch { /* noop */ }
+  }, [])
+
+  // Sync data-theme attribute and dark class on <html>
+  useEffect(() => {
+    const root = document.documentElement
+    root.setAttribute('data-theme', theme)
+
+    if (theme === 'dark') {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+  }, [theme])
+
+  return (
+    <ThemeContext.Provider
+      value={{
+        theme,
+        setTheme,
+        isDark: theme === 'dark',
+        isLightSidebar: theme === 'light',
+      }}
+    >
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+// ── Hook ────────────────────────────────────────────────────────────────────────
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useTheme deve ser usado dentro de <ThemeProvider>')
+  return ctx
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,6 +10,17 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     background-color: #F1F5F9;
+    transition: background-color 0.25s ease, color 0.25s ease;
+  }
+
+  /* ── Dark theme: body background ──────────────────────────── */
+  [data-theme="dark"] body {
+    background-color: #0c1222;
+  }
+
+  /* ── Light theme: slightly lighter body ───────────────────── */
+  [data-theme="light"] body {
+    background-color: #f8fafc;
   }
 }
 
@@ -63,6 +74,13 @@
     border: 1px solid rgba(255, 255, 255, 0.07);
   }
 
+  .glass-light {
+    background: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(0, 0, 0, 0.06);
+  }
+
   /* Base glass card — no hover (add hover via Tailwind in JSX) */
   .glass-card {
     background: rgba(255, 255, 255, 0.04);
@@ -111,7 +129,101 @@
   }
 }
 
-/* ── Keyframes globais ──────────────────────────────────────────────────────── */
+/* ══════════════════════════════════════════════════════════════════════════════
+   DARK THEME — Automatic content adaptations
+   These override common Tailwind classes so content pages adapt automatically
+   without needing per-component changes.
+   ══════════════════════════════════════════════════════════════════════════════ */
+
+/* ── Surfaces ──────────────────────────────────────────────── */
+[data-theme="dark"] .bg-white {
+  background-color: #1e293b;
+}
+[data-theme="dark"] .bg-slate-50 {
+  background-color: #172033;
+}
+[data-theme="dark"] .bg-gray-50 {
+  background-color: #172033;
+}
+[data-theme="dark"] .bg-gray-100 {
+  background-color: #1e293b;
+}
+
+/* ── Primary text (dark-on-light → light-on-dark) ──────────── */
+[data-theme="dark"] .text-slate-800 { color: #e2e8f0; }
+[data-theme="dark"] .text-slate-700 { color: #cbd5e1; }
+[data-theme="dark"] .text-navy      { color: #e2e8f0; }
+
+/* ── Borders ───────────────────────────────────────────────── */
+[data-theme="dark"] .border-slate-200 { border-color: rgba(255,255,255,0.08); }
+[data-theme="dark"] .border-slate-100 { border-color: rgba(255,255,255,0.06); }
+[data-theme="dark"] .border-slate-50  { border-color: rgba(255,255,255,0.05); }
+[data-theme="dark"] .border-gray-50   { border-color: rgba(255,255,255,0.06); }
+
+/* ── Shadows ───────────────────────────────────────────────── */
+[data-theme="dark"] .shadow-card {
+  box-shadow: 0 1px 3px rgba(0,0,0,0.3), 0 1px 2px -1px rgba(0,0,0,0.2);
+}
+[data-theme="dark"] .shadow-card-md {
+  box-shadow: 0 4px 12px rgba(0,0,0,0.25);
+}
+
+/* ── Form inputs ───────────────────────────────────────────── */
+[data-theme="dark"] .input-base {
+  background-color: #0f172a;
+  border-color: rgba(255,255,255,0.1);
+  color: #e2e8f0;
+}
+[data-theme="dark"] .input-base::placeholder {
+  color: #475569;
+}
+
+/* ── Status badge light backgrounds → translucent ──────────── */
+[data-theme="dark"] .bg-amber-50   { background-color: rgba(245,158,11,0.15); }
+[data-theme="dark"] .bg-blue-50    { background-color: rgba(59,130,246,0.15); }
+[data-theme="dark"] .bg-emerald-50 { background-color: rgba(16,185,129,0.15); }
+[data-theme="dark"] .bg-red-50     { background-color: rgba(239,68,68,0.15); }
+[data-theme="dark"] .bg-green-50   { background-color: rgba(34,197,94,0.15); }
+[data-theme="dark"] .bg-violet-50  { background-color: rgba(139,92,246,0.15); }
+[data-theme="dark"] .bg-indigo-50  { background-color: rgba(99,102,241,0.15); }
+[data-theme="dark"] .bg-teal-50    { background-color: rgba(20,184,166,0.15); }
+[data-theme="dark"] .bg-cyan-50    { background-color: rgba(6,182,212,0.15); }
+[data-theme="dark"] .bg-orange-50  { background-color: rgba(249,115,22,0.15); }
+[data-theme="dark"] .bg-rose-50    { background-color: rgba(244,63,94,0.15); }
+
+/* ── Role badge backgrounds → translucent ──────────────────── */
+[data-theme="dark"] .bg-violet-100 { background-color: rgba(139,92,246,0.18); }
+[data-theme="dark"] .bg-indigo-100 { background-color: rgba(99,102,241,0.18); }
+[data-theme="dark"] .bg-amber-100  { background-color: rgba(245,158,11,0.18); }
+[data-theme="dark"] .bg-green-100  { background-color: rgba(34,197,94,0.18); }
+[data-theme="dark"] .bg-sky-100    { background-color: rgba(14,165,233,0.18); }
+[data-theme="dark"] .bg-slate-100  { background-color: rgba(100,116,139,0.18); }
+
+/* ── Scrollbar in dark mode ────────────────────────────────── */
+[data-theme="dark"] .styled-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(100, 116, 139, 0.35);
+}
+[data-theme="dark"] .styled-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: rgba(100, 116, 139, 0.55);
+}
+
+/* ── CategoryCard / selection borders in dark mode ─────────── */
+[data-theme="dark"] .border-slate-200 { border-color: rgba(255,255,255,0.08); }
+
+
+/* ══════════════════════════════════════════════════════════════════════════════
+   LIGHT THEME — Glass card variant for ModuloSelector
+   ══════════════════════════════════════════════════════════════════════════════ */
+
+[data-theme="light"] .glass-card {
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+
+/* ══════════════════════════════════════════════════════════════════════════════
+   Keyframes globais
+   ══════════════════════════════════════════════════════════════════════════════ */
 
 /* Ken Burns — zoom suave nas imagens do slideshow */
 @keyframes kenBurns {

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -2,7 +2,9 @@ import { useState, useEffect } from 'react'
 import { Navigate, useSearchParams } from 'react-router-dom'
 import { Mail, Lock, ArrowRight, Zap, AlertCircle, CheckCircle, Eye, EyeOff } from 'lucide-react'
 import { useAuth } from '../contexts/AuthContext'
+import { useTheme } from '../contexts/ThemeContext'
 import LogoTeg from '../components/LogoTeg'
+import ThemeToggle from '../components/ThemeToggle'
 
 type Mode = 'password' | 'magic'
 type View = 'login' | 'reset' | 'nova-senha' | 'magic-sent'
@@ -95,6 +97,7 @@ function SubmitBtn({ label, busy }: { label: string; busy: boolean }) {
 
 export default function Login() {
   const { user, loading, signIn, signInMagicLink, resetPassword, updatePassword } = useAuth()
+  const { isDark, isLightSidebar: isLight } = useTheme()
   const [searchParams] = useSearchParams()
 
   const [mode,     setMode]     = useState<Mode>('password')
@@ -160,28 +163,37 @@ export default function Login() {
   // ── Views ─────────────────────────────────────────────────────────
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-100 to-slate-200 flex items-center justify-center p-4">
+    <div className={`min-h-screen flex items-center justify-center p-4 ${
+      isDark
+        ? 'bg-[#0c1222]'
+        : 'bg-gradient-to-br from-slate-100 to-slate-200'
+    }`}>
       <div className="w-full max-w-sm">
+
+        {/* Theme toggle */}
+        <div className="flex justify-center mb-4">
+          <ThemeToggle variant={isDark ? 'dark' : 'light'} compact />
+        </div>
 
         {/* Logo / Branding */}
         <div className="text-center mb-7">
           <div className="inline-flex items-center justify-center mb-3">
             <LogoTeg size={72} animated glowing={false} />
           </div>
-          <h1 className="text-2xl font-black text-navy tracking-tight">TEG+</h1>
+          <h1 className={`text-2xl font-black tracking-tight ${isDark ? 'text-white' : 'text-navy'}`}>TEG+</h1>
           <p className="text-xs text-slate-400 mt-0.5 font-medium tracking-wide uppercase">
             Sistema ERP · Acesso Restrito
           </p>
         </div>
 
         {/* Card principal */}
-        <div className="bg-white rounded-2xl shadow-card overflow-hidden">
+        <div className={`rounded-2xl shadow-card overflow-hidden ${isDark ? 'bg-[#1e293b] border border-white/[0.06]' : 'bg-white'}`}>
 
           {/* ── View: LOGIN ── */}
           {view === 'login' && (
             <>
               {/* Tabs modo */}
-              <div className="flex gap-1 bg-slate-100 m-5 mb-0 rounded-xl p-1">
+              <div className={`flex gap-1 m-5 mb-0 rounded-xl p-1 ${isDark ? 'bg-white/5' : 'bg-slate-100'}`}>
                 {([
                   { m: 'password' as Mode, label: 'Senha',       Icon: null as React.ElementType | null },
                   { m: 'magic'    as Mode, label: 'Link Mágico', Icon: Zap  as React.ElementType | null },
@@ -192,8 +204,8 @@ export default function Login() {
                     className={`flex-1 flex items-center justify-center gap-1.5 py-2 px-3 rounded-lg
                       text-xs font-semibold transition-all duration-150
                       ${mode === m
-                        ? 'bg-white shadow text-navy'
-                        : 'text-slate-500 hover:text-navy'
+                        ? isDark ? 'bg-white/10 shadow text-white' : 'bg-white shadow text-navy'
+                        : isDark ? 'text-slate-400 hover:text-white' : 'text-slate-500 hover:text-navy'
                       }`}
                   >
                     {Icon && <Icon size={12} />}

--- a/frontend/src/pages/ModuloSelector.tsx
+++ b/frontend/src/pages/ModuloSelector.tsx
@@ -1,8 +1,10 @@
 import { useNavigate } from 'react-router-dom'
 import { ChevronRight, LogOut, Clock } from 'lucide-react'
 import { useAuth } from '../contexts/AuthContext'
+import { useTheme } from '../contexts/ThemeContext'
 import LogoTeg from '../components/LogoTeg'
 import BannerSlideshow from '../components/BannerSlideshow'
+import ThemeToggle from '../components/ThemeToggle'
 
 // ── Module definitions ─────────────────────────────────────────────────────────
 // active=true → can be accessed now; active=false → "Em breve"
@@ -13,7 +15,9 @@ const MODULOS = [
     icon: '🛒',
     description: 'Requisições, cotações e aprovações',
     iconBg: 'bg-gradient-to-br from-teal-500/25 to-cyan-500/25',
+    iconBgLight: 'bg-gradient-to-br from-teal-50 to-cyan-50',
     iconBorder: 'border-teal-500/50',
+    iconBorderLight: 'border-teal-200',
     accentColor: 'rgba(20,184,166,0.2)',
     active: true,
     route: '/compras',
@@ -24,7 +28,9 @@ const MODULOS = [
     icon: '💰',
     description: 'Contas, aprovações e conciliação',
     iconBg: 'bg-gradient-to-br from-emerald-500/25 to-green-500/25',
+    iconBgLight: 'bg-gradient-to-br from-emerald-50 to-green-50',
     iconBorder: 'border-emerald-500/50',
+    iconBorderLight: 'border-emerald-200',
     accentColor: 'rgba(16,185,129,0.2)',
     active: true,
     route: '/financeiro',
@@ -35,7 +41,9 @@ const MODULOS = [
     icon: '👥',
     description: 'Folha, colaboradores e férias',
     iconBg: 'bg-gradient-to-br from-violet-500/20 to-purple-500/20',
+    iconBgLight: 'bg-gradient-to-br from-violet-50 to-purple-50',
     iconBorder: 'border-violet-500/30',
+    iconBorderLight: 'border-violet-200',
     accentColor: 'rgba(139,92,246,0.15)',
     active: false,
     route: '/rh',
@@ -46,7 +54,9 @@ const MODULOS = [
     icon: '⛑️',
     description: 'Saúde, segurança e meio ambiente',
     iconBg: 'bg-gradient-to-br from-amber-500/20 to-orange-500/20',
+    iconBgLight: 'bg-gradient-to-br from-amber-50 to-orange-50',
     iconBorder: 'border-amber-500/30',
+    iconBorderLight: 'border-amber-200',
     accentColor: 'rgba(245,158,11,0.15)',
     active: false,
     route: '/ssma',
@@ -57,7 +67,9 @@ const MODULOS = [
     icon: '📦',
     description: 'Almoxarifado, inventário e patrimônio',
     iconBg: 'bg-gradient-to-br from-blue-500/20 to-indigo-500/20',
+    iconBgLight: 'bg-gradient-to-br from-blue-50 to-indigo-50',
     iconBorder: 'border-blue-500/30',
+    iconBorderLight: 'border-blue-200',
     accentColor: 'rgba(99,102,241,0.15)',
     active: true,
     route: '/estoque',
@@ -68,7 +80,9 @@ const MODULOS = [
     icon: '🚛',
     description: 'Transportes, NF-e e rastreamento',
     iconBg: 'bg-gradient-to-br from-orange-500/25 to-amber-500/25',
+    iconBgLight: 'bg-gradient-to-br from-orange-50 to-amber-50',
     iconBorder: 'border-orange-500/50',
+    iconBorderLight: 'border-orange-200',
     accentColor: 'rgba(234,88,12,0.2)',
     active: true,
     route: '/logistica',
@@ -79,7 +93,9 @@ const MODULOS = [
     icon: '🚗',
     description: 'Manutenção, checklist e telemetria',
     iconBg: 'bg-gradient-to-br from-rose-500/25 to-pink-500/25',
+    iconBgLight: 'bg-gradient-to-br from-rose-50 to-pink-50',
     iconBorder: 'border-rose-500/50',
+    iconBorderLight: 'border-rose-200',
     accentColor: 'rgba(244,63,94,0.2)',
     active: true,
     route: '/frotas',
@@ -90,7 +106,9 @@ const MODULOS = [
     icon: '📋',
     description: 'Gestão de contratos e SLAs',
     iconBg: 'bg-gradient-to-br from-slate-500/20 to-gray-500/20',
+    iconBgLight: 'bg-gradient-to-br from-slate-50 to-gray-50',
     iconBorder: 'border-slate-500/30',
+    iconBorderLight: 'border-slate-200',
     accentColor: 'rgba(100,116,139,0.15)',
     active: false,
     route: '/contratos',
@@ -100,6 +118,7 @@ const MODULOS = [
 // ── Component ──────────────────────────────────────────────────────────────────
 export default function ModuloSelector() {
   const { perfil, hasModule, signOut, isAdmin } = useAuth()
+  const { isLightSidebar: isLight } = useTheme()
   const navigate = useNavigate()
 
   const primeiroNome = (perfil?.nome ?? 'Usuário').split(' ')[0]
@@ -121,6 +140,175 @@ export default function ModuloSelector() {
     navigate('/login', { replace: true })
   }
 
+  // ── Light theme variant ─────────────────────────────────────────────────────
+  if (isLight) {
+    return (
+      <div className="min-h-screen bg-slate-50 relative overflow-x-hidden flex flex-col">
+
+        {/* ── Header ────────────────────────────────────────────── */}
+        <header className="relative z-10 flex items-center justify-between px-5 sm:px-8 pt-6 animate-fade-in">
+          <div className="flex items-center gap-2.5">
+            <div className="flex items-center gap-1.5">
+              <div className="w-1.5 h-1.5 rounded-full bg-teal-500 animate-pulse" />
+              <span className="text-[11px] font-semibold text-teal-600 uppercase tracking-widest">
+                TEG+ ERP
+              </span>
+            </div>
+            <span className="text-slate-300">·</span>
+            <span className="text-[11px] font-medium text-slate-400">v2.0</span>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <ThemeToggle variant="light" compact />
+            <button
+              onClick={handleLogout}
+              className="flex items-center gap-1.5 text-xs text-slate-400 hover:text-slate-600
+                transition-colors py-1.5 px-3 rounded-lg hover:bg-slate-100"
+            >
+              <LogOut size={13} />
+              Sair
+            </button>
+          </div>
+        </header>
+
+        {/* ── Hero ──────────────────────────────────────────────── */}
+        <section className="relative z-10 flex flex-col items-center px-5 pt-10 pb-6">
+          <div className="animate-fade-in delay-100 mb-5 rounded-[28px] p-3">
+            <LogoTeg size={96} animated glowing={false} />
+          </div>
+
+          <h1 className="text-6xl font-black tracking-tighter text-gradient leading-none animate-fade-in-up delay-150">
+            TEG+
+          </h1>
+
+          <p className="text-sm font-medium text-slate-400 mt-1.5 mb-5 animate-fade-in-up delay-200 tracking-wide">
+            Enterprise Resource Planning
+          </p>
+
+          <div className="text-center animate-fade-in-up delay-250">
+            <p className="text-slate-800 text-xl font-bold">
+              {saudacao},{' '}
+              <span className="text-gradient-teal">{primeiroNome}</span>
+            </p>
+            <p className="text-slate-400 text-sm mt-1">
+              Selecione um módulo para acessar o sistema
+            </p>
+          </div>
+
+          <div
+            className="mt-6 w-32 h-px animate-fade-in delay-400"
+            style={{
+              background: 'linear-gradient(90deg, transparent, rgba(20,184,166,0.4), transparent)',
+            }}
+          />
+        </section>
+
+        {/* ── Banner Slideshow ──────────────────────────────────── */}
+        <div className="relative z-10 pb-5">
+          <BannerSlideshow />
+        </div>
+
+        {/* ── Module grid ──────────────────────────────────────── */}
+        <section className="relative z-10 flex-1 px-4 sm:px-6 pb-10 max-w-2xl mx-auto w-full">
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4">
+            {MODULOS.map((mod, i) => {
+              const accessible = canAccess(mod)
+              const isCompras  = mod.key === 'compras'
+              const isAdminRH  = isAdmin && mod.key === 'rh' && !mod.active
+              const delay      = 340 + i * 75
+
+              return (
+                <button
+                  key={mod.key}
+                  onClick={() => accessible && navigate(mod.route)}
+                  disabled={!accessible}
+                  aria-label={`${accessible ? 'Acessar' : 'Em breve:'} ${mod.label}`}
+                  className={[
+                    'group relative rounded-2xl p-4 sm:p-5 text-left',
+                    'bg-white border border-slate-200/80 shadow-card animate-scale-in',
+                    'transition-all duration-250',
+                    accessible
+                      ? 'cursor-pointer hover:-translate-y-1 hover:shadow-card-md hover:border-teal-300'
+                      : 'cursor-not-allowed opacity-50 pointer-events-none',
+                    isCompras && accessible
+                      ? 'border-teal-300 bg-teal-50/30 shadow-card-md'
+                      : '',
+                    isAdminRH
+                      ? 'border-violet-200 bg-violet-50/30 opacity-100'
+                      : '',
+                  ].join(' ')}
+                  style={{ animationDelay: `${delay}ms` }}
+                >
+                  {/* Admin-only badge */}
+                  {isAdminRH && (
+                    <div className="absolute top-2 right-2 text-[8px] font-bold px-1.5 py-0.5 rounded-md bg-violet-100 text-violet-600 border border-violet-200">
+                      Admin
+                    </div>
+                  )}
+
+                  {/* Icon container */}
+                  <div
+                    className={[
+                      'w-11 h-11 rounded-xl flex items-center justify-center text-xl mb-3.5',
+                      mod.iconBgLight,
+                      `border ${mod.iconBorderLight}`,
+                      'transition-transform duration-300',
+                      accessible ? 'group-hover:scale-110' : '',
+                    ].join(' ')}
+                  >
+                    {mod.icon}
+                  </div>
+
+                  {/* Label */}
+                  <p className={`text-[13px] font-bold leading-tight mb-1 ${accessible ? 'text-slate-800' : 'text-slate-400'}`}>
+                    {mod.label}
+                  </p>
+
+                  {/* Description / Em breve */}
+                  <p className={`text-[10px] leading-snug ${accessible ? 'text-slate-500' : 'text-slate-400'}`}>
+                    {accessible ? mod.description : 'Em breve'}
+                  </p>
+
+                  {/* Footer row */}
+                  {accessible ? (
+                    <div className="flex items-center justify-between mt-4">
+                      {isCompras ? (
+                        <span className="text-[9px] font-bold text-teal-600 bg-teal-100
+                          px-2 py-0.5 rounded-full uppercase tracking-wider">
+                          Disponível
+                        </span>
+                      ) : isAdminRH ? (
+                        <span className="text-[9px] font-semibold text-violet-500">Mural Admin</span>
+                      ) : (
+                        <span className="text-[9px] font-semibold text-slate-400">Acessar</span>
+                      )}
+                      <ChevronRight
+                        size={13}
+                        className={`transition-transform duration-200 group-hover:translate-x-0.5
+                          ${isCompras ? 'text-teal-500' : isAdminRH ? 'text-violet-500' : 'text-slate-400'}`}
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-1 mt-4">
+                      <Clock size={10} className="text-slate-400" />
+                      <span className="text-[9px] text-slate-400 font-medium">Em desenvolvimento</span>
+                    </div>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+
+          {/* Footer */}
+          <p className="text-center text-[10px] text-slate-400 mt-8 animate-fade-in delay-1000">
+            Acesso restrito a colaboradores autorizados · TEG+ ERP v2.0
+          </p>
+        </section>
+      </div>
+    )
+  }
+
+  // ── Original / Dark theme variant (default) ─────────────────────────────────
   return (
     <div className="min-h-screen bg-[#060D1B] relative overflow-x-hidden flex flex-col">
 
@@ -163,14 +351,17 @@ export default function ModuloSelector() {
           <span className="text-[11px] font-medium text-slate-500">v2.0</span>
         </div>
 
-        <button
-          onClick={handleLogout}
-          className="flex items-center gap-1.5 text-xs text-slate-500 hover:text-slate-300
-            transition-colors py-1.5 px-3 rounded-lg hover:bg-white/5"
-        >
-          <LogOut size={13} />
-          Sair
-        </button>
+        <div className="flex items-center gap-3">
+          <ThemeToggle variant="dark" compact />
+          <button
+            onClick={handleLogout}
+            className="flex items-center gap-1.5 text-xs text-slate-500 hover:text-slate-300
+              transition-colors py-1.5 px-3 rounded-lg hover:bg-white/5"
+          >
+            <LogOut size={13} />
+            Sair
+          </button>
+        </div>
       </header>
 
       {/* ── Hero ──────────────────────────────────────────────── */}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  darkMode: 'class',
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
Implement a complete theme switching system allowing users to toggle between Original (dark sidebar + light content), Dark (full dark mode), and Light (white sidebar + light content) themes.

New files:
- ThemeContext: manages theme state with localStorage persistence
- ThemeToggle: segmented control component (Original/Dark/Light)

Updated:
- All 6 module layouts with conditional sidebar/header/nav styling
- ModuloSelector with full light variant (white cards, light bg)
- Login page with dark mode support
- index.css with dark theme CSS auto-adaptations for content pages
- tailwind.config.js with darkMode: 'class'

https://claude.ai/code/session_01174S8hE3fCvC8UhYZ5MC9Z