### PR TITLE
fix(auth): add dedicated password reset page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import Layout from './components/Layout'
 
 // Páginas públicas
 import Login from './pages/Login'
+import ResetPassword from './pages/ResetPassword'
 
 // Páginas privadas
 import ModuloSelector from './pages/ModuloSelector'
@@ -105,7 +106,7 @@ export default function App() {
       <Routes>
         {/* ── Públicas ──────────────────────────────────────── */}
         <Route path="/login"      element={<Login />} />
-        <Route path="/nova-senha" element={<Login />} />
+        <Route path="/nova-senha" element={<ResetPassword />} />
 
         {/* Aprovação por token: pública (aprovador externo) */}
         <Route path="/aprovacao/:token" element={<Aprovacao />} />

--- a/frontend/src/components/PrivateRoute.tsx
+++ b/frontend/src/components/PrivateRoute.tsx
@@ -37,7 +37,7 @@ function AuthLoading() {
 
 // ── Guard: usuário autenticado ─────────────────────────────────────────────────
 export function PrivateRoute() {
-  const { user, loading, perfilReady, perfil } = useAuth()
+  const { user, loading, perfilReady, perfil, pendingPasswordReset } = useAuth()
   const location = useLocation()
 
   // Enquanto carrega ou enquanto o safety net aguarda → spinner
@@ -51,6 +51,11 @@ export function PrivateRoute() {
     return <Navigate to="/login" state={{ from: location }} replace />
   }
 
+  // Recovery link: redireciona para tela dedicada de redefinição de senha
+  if (pendingPasswordReset) {
+    return <Navigate to="/nova-senha" replace />
+  }
+
   return (
     <>
       {perfil && !perfil.senha_definida && <SetPasswordModal />}
@@ -61,7 +66,7 @@ export function PrivateRoute() {
 
 // ── Guard: apenas admins ───────────────────────────────────────────────────────
 export function AdminRoute() {
-  const { user, loading, perfilReady, perfil, isAdmin } = useAuth()
+  const { user, loading, perfilReady, perfil, isAdmin, pendingPasswordReset } = useAuth()
   const location = useLocation()
 
   if (loading || !perfilReady) return <AuthLoading />
@@ -70,6 +75,11 @@ export function AdminRoute() {
 
   if (!user) {
     return <Navigate to="/login" state={{ from: location }} replace />
+  }
+
+  // Recovery link: redireciona para tela dedicada de redefinição de senha
+  if (pendingPasswordReset) {
+    return <Navigate to="/nova-senha" replace />
   }
 
   if (!isAdmin) {

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -89,6 +89,9 @@ interface AuthContextType {
   reloadPerfil: () => Promise<void>
   markSenhaDefinida: () => Promise<{ error: string | null }>
 
+  pendingPasswordReset: boolean
+  clearPasswordReset: () => void
+
   role: Role
   roleLabel: string
   isAdmin: boolean
@@ -109,6 +112,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [perfil,      setPerfil]      = useState<Perfil | null>(null)
   const [loading,     setLoading]     = useState(true)
   const [perfilReady, setPerfilReady] = useState(false)
+  const [pendingPasswordReset, setPendingPasswordReset] = useState(false)
 
   // Guard: evita chamadas concorrentes a loadPerfil
   const loadingRef    = useRef(false)
@@ -199,6 +203,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setUser(session?.user ?? null)
         userRef.current = session?.user ?? null
 
+        // Detecta redirecionamento de recovery link
+        if (_event === 'PASSWORD_RECOVERY') {
+          setPendingPasswordReset(true)
+        }
+
         if (session?.user) {
           // Reset mutex — chamada anterior pode ter travado sem resetar
           loadingRef.current = false
@@ -280,6 +289,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return { error: null }
   }
 
+  const clearPasswordReset = () => setPendingPasswordReset(false)
+
   const markSenhaDefinida = async () => {
     if (!user) return { error: 'Não autenticado' }
     const { error } = await supabase
@@ -309,6 +320,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     updatePerfil,
     reloadPerfil,
     markSenhaDefinida,
+    pendingPasswordReset,
+    clearPasswordReset,
     role,
     roleLabel:  ROLE_LABEL[role],
     isAdmin:    role === 'admin',

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,12 +1,12 @@
-import { useState, useEffect } from 'react'
-import { Navigate, useSearchParams } from 'react-router-dom'
+import { useState } from 'react'
+import { Navigate } from 'react-router-dom'
 import { Mail, Lock, ArrowRight, AlertCircle, CheckCircle, Eye, EyeOff } from 'lucide-react'
 import { useAuth } from '../contexts/AuthContext'
 import { useTheme } from '../contexts/ThemeContext'
 import LogoTeg from '../components/LogoTeg'
 import ThemeToggle from '../components/ThemeToggle'
 
-type View = 'login' | 'reset' | 'nova-senha'
+type View = 'login' | 'reset'
 
 // ── Sub-componentes fora do Login para evitar remount a cada render ──────────
 // IMPORTANTE: definir componentes DENTRO do componente pai faz React
@@ -95,27 +95,18 @@ function SubmitBtn({ label, busy }: { label: string; busy: boolean }) {
 // ── Componente principal ─────────────────────────────────────────────────────
 
 export default function Login() {
-  const { user, loading, signIn, resetPassword, updatePassword } = useAuth()
+  const { user, loading, signIn, resetPassword } = useAuth()
   const { isDark, isLightSidebar: isLight } = useTheme()
-  const [searchParams] = useSearchParams()
 
   const [view,     setView]     = useState<View>('login')
   const [email,    setEmail]    = useState('')
   const [password, setPassword] = useState('')
-  const [newPass,  setNewPass]  = useState('')
   const [showPass, setShowPass] = useState(false)
   const [busy,     setBusy]     = useState(false)
   const [error,    setError]    = useState<string | null>(null)
   const [success,  setSuccess]  = useState<string | null>(null)
 
-  // Detecta se é um link de "nova senha" (type=recovery na URL)
-  useEffect(() => {
-    if (searchParams.get('type') === 'recovery') {
-      setView('nova-senha')
-    }
-  }, [searchParams])
-
-  if (!loading && user && view !== 'nova-senha') {
+  if (!loading && user) {
     return <Navigate to="/" replace />
   }
 
@@ -136,19 +127,6 @@ export default function Login() {
     setBusy(false)
     if (error) { setError(error); return }
     setSuccess('Link de recuperação enviado! Verifique seu e-mail.')
-  }
-
-  const handleNewPassword = async (e: React.FormEvent) => {
-    e.preventDefault(); clr(); setBusy(true)
-    if (newPass.length < 6) {
-      setError('A senha deve ter pelo menos 6 caracteres')
-      setBusy(false); return
-    }
-    const { error } = await updatePassword(newPass)
-    setBusy(false)
-    if (error) { setError(error); return }
-    setSuccess('Senha atualizada! Redirecionando...')
-    setTimeout(() => setView('login'), 2000)
   }
 
   // ── Views ─────────────────────────────────────────────────────────
@@ -244,34 +222,6 @@ export default function Login() {
                 className="w-full text-center text-xs text-slate-500 hover:text-navy transition-colors">
                 ← Voltar ao login
               </button>
-            </form>
-          )}
-
-          {/* ── View: NOVA SENHA (link de recovery) ── */}
-          {view === 'nova-senha' && (
-            <form onSubmit={handleNewPassword} className="p-5 space-y-4">
-              <div>
-                <p className="font-bold text-navy">Criar nova senha</p>
-                <p className="text-xs text-slate-500 mt-0.5">
-                  Escolha uma senha segura para sua conta
-                </p>
-              </div>
-              <InputField
-                label="Nova senha"
-                type={showPass ? 'text' : 'password'}
-                value={newPass}
-                onChange={v => { setNewPass(v); clr() }}
-                placeholder="mínimo 6 caracteres"
-                icon={Lock} autoFocus
-                suffix={
-                  <button type="button" onClick={() => setShowPass(v => !v)}
-                    className="text-slate-400 hover:text-slate-600">
-                    {showPass ? <EyeOff size={14} /> : <Eye size={14} />}
-                  </button>
-                }
-              />
-              <Feedback error={error} success={success} />
-              <SubmitBtn label="Salvar nova senha" busy={busy} />
             </form>
           )}
 

--- a/frontend/src/pages/ResetPassword.tsx
+++ b/frontend/src/pages/ResetPassword.tsx
@@ -1,0 +1,165 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Lock, Eye, EyeOff, ShieldCheck, AlertCircle, CheckCircle, ArrowRight } from 'lucide-react'
+import { useAuth } from '../contexts/AuthContext'
+import { useTheme } from '../contexts/ThemeContext'
+import LogoTeg from '../components/LogoTeg'
+
+/**
+ * Página dedicada para redefinição de senha.
+ * Exibida quando o usuário clica no link de recovery do Supabase.
+ * O AuthContext detecta o evento PASSWORD_RECOVERY e seta pendingPasswordReset=true,
+ * que faz o PrivateRoute redirecionar para esta página.
+ */
+export default function ResetPassword() {
+  const { updatePassword, clearPasswordReset } = useAuth()
+  const { isDark } = useTheme()
+  const navigate = useNavigate()
+
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [showPass, setShowPass] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    if (password.length < 6) {
+      setError('A senha deve ter pelo menos 6 caracteres')
+      return
+    }
+    if (password !== confirm) {
+      setError('As senhas não coincidem')
+      return
+    }
+
+    setBusy(true)
+    const { error: passErr } = await updatePassword(password)
+    setBusy(false)
+
+    if (passErr) {
+      setError(passErr)
+      return
+    }
+
+    setSuccess(true)
+    clearPasswordReset()
+    setTimeout(() => navigate('/', { replace: true }), 2000)
+  }
+
+  return (
+    <div className={`min-h-screen flex items-center justify-center p-4 ${
+      isDark
+        ? 'bg-[#0c1222]'
+        : 'bg-gradient-to-br from-slate-100 to-slate-200'
+    }`}>
+      <div className="w-full max-w-sm">
+        {/* Logo */}
+        <div className="text-center mb-7">
+          <div className="inline-flex items-center justify-center mb-3">
+            <LogoTeg size={72} animated glowing={false} />
+          </div>
+          <h1 className={`text-2xl font-black tracking-tight ${isDark ? 'text-white' : 'text-navy'}`}>TEG+</h1>
+          <p className="text-xs text-slate-400 mt-0.5 font-medium tracking-wide uppercase">
+            Redefinição de Senha
+          </p>
+        </div>
+
+        {/* Card */}
+        <div className={`rounded-2xl shadow-card overflow-hidden ${isDark ? 'bg-[#1e293b] border border-white/[0.06]' : 'bg-white'}`}>
+          {success ? (
+            <div className="p-8 text-center space-y-4">
+              <div className="w-16 h-16 rounded-full bg-green-100 flex items-center justify-center mx-auto">
+                <CheckCircle size={28} className="text-green-600" />
+              </div>
+              <div>
+                <p className={`font-bold text-lg ${isDark ? 'text-white' : 'text-navy'}`}>Senha atualizada!</p>
+                <p className="text-sm text-slate-500 mt-1">Redirecionando...</p>
+              </div>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="p-5 space-y-4">
+              <div className="flex items-center gap-3 mb-1">
+                <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center">
+                  <ShieldCheck size={20} className="text-primary" />
+                </div>
+                <div>
+                  <p className={`font-bold ${isDark ? 'text-white' : 'text-navy'}`}>Criar nova senha</p>
+                  <p className="text-xs text-slate-500">Escolha uma senha segura para sua conta</p>
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-xs font-semibold text-slate-600 mb-1.5">Nova senha</label>
+                <div className="relative">
+                  <Lock size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none" />
+                  <input
+                    type={showPass ? 'text' : 'password'}
+                    value={password}
+                    onChange={e => { setPassword(e.target.value); setError(null) }}
+                    placeholder="Mínimo 6 caracteres"
+                    autoFocus
+                    required
+                    autoComplete="new-password"
+                    className="w-full pl-9 pr-10 py-2.5 rounded-xl border border-slate-200 text-sm
+                      focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary
+                      bg-slate-50 focus:bg-white transition-all"
+                  />
+                  <button type="button" onClick={() => setShowPass(v => !v)}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 transition-colors">
+                    {showPass ? <EyeOff size={14} /> : <Eye size={14} />}
+                  </button>
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-xs font-semibold text-slate-600 mb-1.5">Confirmar senha</label>
+                <div className="relative">
+                  <Lock size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none" />
+                  <input
+                    type={showPass ? 'text' : 'password'}
+                    value={confirm}
+                    onChange={e => { setConfirm(e.target.value); setError(null) }}
+                    placeholder="Repita a senha"
+                    required
+                    autoComplete="new-password"
+                    className="w-full pl-9 pr-4 py-2.5 rounded-xl border border-slate-200 text-sm
+                      focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary
+                      bg-slate-50 focus:bg-white transition-all"
+                  />
+                </div>
+              </div>
+
+              {error && (
+                <div className="flex items-start gap-2 bg-red-50 border border-red-100 text-red-700 rounded-xl px-3 py-2.5 text-sm">
+                  <AlertCircle size={15} className="mt-0.5 shrink-0" />
+                  <span>{error}</span>
+                </div>
+              )}
+
+              <button
+                type="submit"
+                disabled={busy}
+                className="w-full py-3 rounded-xl bg-primary text-white font-semibold text-sm
+                  flex items-center justify-center gap-2
+                  hover:bg-indigo-500 active:scale-[0.98] transition-all disabled:opacity-60"
+              >
+                {busy
+                  ? <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                  : <><span>Salvar nova senha</span><ArrowRight size={14} /></>
+                }
+              </button>
+            </form>
+          )}
+        </div>
+
+        <p className="text-center text-xs text-slate-400 mt-5">
+          TEG+ ERP v2.0 · Acesso apenas para colaboradores autorizados
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Fixes recovery links logging users in directly instead of showing a password reset screen
- Supabase puts `type=recovery` in URL hash fragments (not query params), so the old `searchParams.get('type')` approach never worked
- Replaces with `PASSWORD_RECOVERY` event detection in `AuthContext.onAuthStateChange`
- Adds dedicated `ResetPassword.tsx` page at `/nova-senha` with password + confirm fields
- `PrivateRoute`/`AdminRoute` now redirect to `/nova-senha` when a recovery is pending
- Cleans up broken recovery detection and `nova-senha` view from `Login.tsx`

## Test plan
- [ ] Click "Esqueci a senha" on login, enter email, receive recovery link
- [ ] Click recovery link → should land on `/nova-senha` with branded reset form
- [ ] Enter new password + confirm, submit → password updated, redirected to home
- [ ] Verify normal login flow still works without regressions
- [ ] Verify first-login `SetPasswordModal` still works for magic link invites

🤖 Generated with [Claude Code](https://claude.com/claude-code)