### PR TITLE
feat(compras): add item catalog autocomplete to RC wizard

### DIFF
--- a/frontend/src/components/ItemAutocomplete.tsx
+++ b/frontend/src/components/ItemAutocomplete.tsx
@@ -1,0 +1,322 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { Search, Plus, Loader2, Check, Package } from 'lucide-react'
+import { useItemCatalogSearch, useSalvarItem } from '../hooks/useEstoque'
+import { useAuth } from '../contexts/AuthContext'
+import { supabase } from '../services/supabase'
+import type { EstItem } from '../types/estoque'
+
+// ── Map RC category (cmp_categorias.codigo) → est_itens.categoria ───────────
+const CATEGORY_MAP: Record<string, string[]> = {
+  // Uppercase codes from cmp_categorias table
+  MATERIAIS_OBRA:  ['Material Elétrico', 'Almoxarifado Geral'],
+  EPI_EPC:         ['EPI/EPC'],
+  FERRAMENTAL:     ['Ferramental'],
+  FROTA_EQUIP:     ['Ferramental', 'Almoxarifado Geral'],
+  SERVICOS:        [],
+  LOCACAO:         [],
+  MOBILIZACAO:     [],
+  ALIMENTACAO:     [],
+  ALOJAMENTO:      [],
+  ESCRITORIO:      ['Material de Escritório'],
+  CENTRO_DIST:     ['Almoxarifado Geral'],
+  AQUISICOES_ESP:  ['Material Elétrico', 'Almoxarifado Geral', 'EPI/EPC', 'Ferramental', 'Material de Escritório'],
+  // Lowercase fallback (for AI parser)
+  materiais_obra:  ['Material Elétrico', 'Almoxarifado Geral'],
+  epi_epc:         ['EPI/EPC'],
+  ferramental:     ['Ferramental'],
+  frota_equip:     ['Ferramental', 'Almoxarifado Geral'],
+  servicos:        [],
+  locacao_veic:    [],
+  mobilizacao:     [],
+  alimentacao:     [],
+  escritorio:      ['Material de Escritório'],
+  consumo:         ['Almoxarifado Geral'],
+}
+
+export function getCategoriaEstoque(categoriaRC: string): string[] {
+  return CATEGORY_MAP[categoriaRC] ?? CATEGORY_MAP[categoriaRC.toUpperCase()] ?? []
+}
+
+// ── Unidades do enum est_unidade ────────────────────────────────────────────
+const UNIDADES_ESTOQUE = ['UN', 'M', 'M2', 'M3', 'KG', 'TON', 'L', 'CX', 'PCT', 'RL', 'PR', 'JG']
+
+// Map DB enum → RC select values (NovaRequisicao uses lowercase)
+const UNIDADE_DB_TO_RC: Record<string, string> = {
+  UN: 'un', M: 'm', M2: 'm²', M3: 'm³', KG: 'kg', TON: 'ton',
+  L: 'L', CX: 'cx', PCT: 'pc', RL: 'rl', PR: 'par', JG: 'jg',
+}
+
+// ── Props ───────────────────────────────────────────────────────────────────
+interface ItemAutocompleteProps {
+  value: string
+  onChange: (desc: string) => void
+  onSelectCatalog: (item: { id: string; codigo: string; descricao: string; unidade: string; valor_medio: number }) => void
+  categoriaRC: string
+  placeholder?: string
+  isDark?: boolean
+}
+
+export default function ItemAutocomplete({
+  value, onChange, onSelectCatalog, categoriaRC, placeholder, isDark,
+}: ItemAutocompleteProps) {
+  const [search, setSearch] = useState('')
+  const [showDropdown, setShowDropdown] = useState(false)
+  const [showCreateForm, setShowCreateForm] = useState(false)
+  const [newDesc, setNewDesc] = useState('')
+  const [newUnidade, setNewUnidade] = useState('UN')
+  const [saving, setSaving] = useState(false)
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>()
+  const wrapperRef = useRef<HTMLDivElement>(null)
+
+  const categoriasEstoque = getCategoriaEstoque(categoriaRC)
+  const hasAutocomplete = categoriasEstoque.length > 0
+
+  const { data: results = [], isLoading } = useItemCatalogSearch(categoriasEstoque, search)
+  const salvarItem = useSalvarItem()
+  const { isAdmin, perfil } = useAuth()
+
+  // Close on outside click
+  useEffect(() => {
+    function onClick(e: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setShowDropdown(false)
+        setShowCreateForm(false)
+      }
+    }
+    document.addEventListener('mousedown', onClick)
+    return () => document.removeEventListener('mousedown', onClick)
+  }, [])
+
+  const handleInputChange = useCallback((v: string) => {
+    onChange(v)
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => setSearch(v.trim()), 300)
+    setShowDropdown(true)
+    setShowCreateForm(false)
+  }, [onChange])
+
+  function selectItem(item: EstItem) {
+    const dbUnit = (item.unidade || 'UN').toUpperCase()
+    onSelectCatalog({
+      id: item.id,
+      codigo: item.codigo,
+      descricao: item.descricao,
+      unidade: UNIDADE_DB_TO_RC[dbUnit] || dbUnit.toLowerCase(),
+      valor_medio: item.valor_medio ?? 0,
+    })
+    setShowDropdown(false)
+    setShowCreateForm(false)
+    setSearch('')
+  }
+
+  function openCreateForm() {
+    setNewDesc(value || search)
+    setNewUnidade('UN')
+    setShowCreateForm(true)
+  }
+
+  async function handleCreate() {
+    if (!newDesc.trim()) return
+    setSaving(true)
+    try {
+      const categoria = categoriasEstoque[0] || 'Almoxarifado Geral'
+      // Generate a unique code
+      const prefix = categoria === 'Material Elétrico' ? 'ME'
+        : categoria === 'EPI/EPC' ? 'EP'
+        : categoria === 'Ferramental' ? 'FE'
+        : categoria === 'Material de Escritório' ? 'ES'
+        : 'AG'
+      const code = `${prefix}-${Date.now().toString(36).toUpperCase()}`
+
+      if (isAdmin) {
+        // Direct insert
+        const { data, error } = await supabase
+          .from('est_itens')
+          .insert({
+            codigo: code,
+            descricao: newDesc.trim(),
+            categoria,
+            unidade: newUnidade,
+            ativo: true,
+            valor_medio: 0,
+          })
+          .select('id, codigo, descricao, unidade, valor_medio')
+          .single()
+        if (error) throw error
+
+        const createdUnit = (data.unidade || 'UN').toUpperCase()
+        onSelectCatalog({
+          id: data.id,
+          codigo: data.codigo,
+          descricao: data.descricao,
+          unidade: UNIDADE_DB_TO_RC[createdUnit] || createdUnit.toLowerCase(),
+          valor_medio: 0,
+        })
+      } else {
+        // Pre-cadastro
+        await supabase.from('sys_pre_cadastros').insert({
+          entidade: 'itens',
+          tabela_destino: 'est_itens',
+          dados: {
+            codigo: code,
+            descricao: newDesc.trim(),
+            categoria,
+            unidade: newUnidade,
+            ativo: true,
+            valor_medio: 0,
+          },
+          status: 'pendente',
+          solicitado_por: perfil?.auth_id,
+          solicitante_nome: perfil?.nome,
+        })
+        // Just use the typed description
+        onChange(newDesc.trim())
+      }
+
+      setShowDropdown(false)
+      setShowCreateForm(false)
+    } catch (err) {
+      console.error('Erro ao criar item:', err)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  // Highlight matching text
+  function highlight(text: string) {
+    if (!search.trim()) return text
+    const idx = text.toLowerCase().indexOf(search.toLowerCase())
+    if (idx < 0) return text
+    return (
+      <>
+        {text.slice(0, idx)}
+        <span className="font-bold text-teal-600">{text.slice(idx, idx + search.length)}</span>
+        {text.slice(idx + search.length)}
+      </>
+    )
+  }
+
+  const showResults = showDropdown && hasAutocomplete && search.length >= 2
+  const bg = isDark ? 'bg-slate-800 border-slate-600' : 'bg-white border-slate-200'
+  const dropdownBg = isDark ? 'bg-slate-800 border-slate-600' : 'bg-white border-slate-200'
+  const hoverBg = isDark ? 'hover:bg-slate-700' : 'hover:bg-teal-50'
+  const textColor = isDark ? 'text-slate-200' : 'text-slate-700'
+  const mutedText = isDark ? 'text-slate-400' : 'text-slate-400'
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <div className="relative">
+        {hasAutocomplete && (
+          <Search size={14} className={`absolute left-3 top-1/2 -translate-y-1/2 ${mutedText}`} />
+        )}
+        <input
+          value={value}
+          onChange={e => handleInputChange(e.target.value)}
+          onFocus={() => { if (value.length >= 2 && hasAutocomplete) setShowDropdown(true) }}
+          placeholder={placeholder || (hasAutocomplete ? 'Buscar item do catálogo...' : 'Descrição do item')}
+          className={`w-full border rounded-xl ${hasAutocomplete ? 'pl-9' : 'px-3'} pr-3 py-2 text-sm focus:ring-2 focus:ring-teal-300 outline-none ${bg} ${textColor}`}
+          required
+        />
+        {isLoading && hasAutocomplete && (
+          <Loader2 size={14} className="absolute right-3 top-1/2 -translate-y-1/2 text-teal-500 animate-spin" />
+        )}
+      </div>
+
+      {/* Dropdown */}
+      {showResults && (
+        <div className={`absolute z-50 left-0 right-0 top-full mt-1 ${dropdownBg} rounded-xl border shadow-lg overflow-hidden max-h-64 overflow-y-auto`}>
+          {results.length > 0 ? (
+            <>
+              {results.map(item => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onMouseDown={e => e.preventDefault()}
+                  onClick={() => selectItem(item)}
+                  className={`w-full text-left px-3 py-2.5 text-sm ${textColor} ${hoverBg} transition-colors flex items-center gap-2 border-b border-slate-100 last:border-0`}
+                >
+                  <Package size={14} className="text-teal-500 shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className={`text-[10px] font-mono ${mutedText} shrink-0`}>{item.codigo}</span>
+                      <span className="truncate">{highlight(item.descricao)}</span>
+                    </div>
+                    {item.descricao_complementar && (
+                      <div className={`text-[11px] ${mutedText} truncate`}>{item.descricao_complementar}</div>
+                    )}
+                  </div>
+                  <div className="text-right shrink-0">
+                    <div className={`text-[10px] ${mutedText}`}>{item.unidade}</div>
+                    {(item.valor_medio ?? 0) > 0 && (
+                      <div className="text-[11px] font-semibold text-teal-600">
+                        R$ {(item.valor_medio ?? 0).toFixed(2)}
+                      </div>
+                    )}
+                  </div>
+                </button>
+              ))}
+            </>
+          ) : !isLoading ? (
+            <div className={`px-3 py-3 text-sm ${mutedText} text-center`}>
+              Nenhum item encontrado para "{search}"
+            </div>
+          ) : null}
+
+          {/* + Cadastrar Item button */}
+          {!showCreateForm && (
+            <button
+              type="button"
+              onMouseDown={e => e.preventDefault()}
+              onClick={openCreateForm}
+              className={`w-full text-left px-3 py-2.5 text-sm font-semibold text-teal-600 ${hoverBg} transition-colors flex items-center gap-2 border-t ${isDark ? 'border-slate-600' : 'border-slate-200'}`}
+            >
+              <Plus size={14} />
+              {isAdmin ? 'Cadastrar novo item' : 'Solicitar cadastro de item'}
+            </button>
+          )}
+
+          {/* Inline create form */}
+          {showCreateForm && (
+            <div className={`p-3 border-t ${isDark ? 'border-slate-600 bg-slate-750' : 'border-slate-200 bg-slate-50'} space-y-2`}>
+              <div className={`text-[10px] font-bold uppercase tracking-wider ${mutedText}`}>
+                {isAdmin ? 'Novo Item' : 'Pré-cadastro'}
+              </div>
+              <input
+                value={newDesc}
+                onChange={e => setNewDesc(e.target.value)}
+                placeholder="Descrição do item"
+                className={`w-full border rounded-lg px-2.5 py-1.5 text-sm ${bg} ${textColor} focus:ring-2 focus:ring-teal-300 outline-none`}
+                autoFocus
+                onMouseDown={e => e.preventDefault()}
+              />
+              <div className="flex gap-2">
+                <select
+                  value={newUnidade}
+                  onChange={e => setNewUnidade(e.target.value)}
+                  className={`border rounded-lg px-2 py-1.5 text-sm ${bg} ${textColor} focus:ring-2 focus:ring-teal-300 outline-none`}
+                >
+                  {UNIDADES_ESTOQUE.map(u => <option key={u} value={u}>{u}</option>)}
+                </select>
+                <button
+                  type="button"
+                  disabled={!newDesc.trim() || saving}
+                  onMouseDown={e => e.preventDefault()}
+                  onClick={handleCreate}
+                  className="flex-1 flex items-center justify-center gap-1.5 bg-teal-600 text-white text-sm font-semibold rounded-lg px-3 py-1.5 hover:bg-teal-700 disabled:opacity-50 transition"
+                >
+                  {saving ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
+                  {isAdmin ? 'Criar' : 'Enviar'}
+                </button>
+              </div>
+              {!isAdmin && (
+                <p className={`text-[10px] ${mutedText}`}>
+                  Será enviado para aprovação do administrador
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useAiParse.ts
+++ b/frontend/src/hooks/useAiParse.ts
@@ -1,6 +1,8 @@
 import { useMutation } from '@tanstack/react-query'
 import type { AiParseResult } from '../types'
 import { api } from '../services/api'
+import { supabase } from '../services/supabase'
+import { getCategoriaEstoque } from '../components/ItemAutocomplete'
 
 // ── Tipos de arquivo aceitos ────────────────────────────────────────────────
 const BINARY_EXTS = /\.(pdf|xlsx|xls|jpg|jpeg|png|gif|webp|bmp|heic)$/i
@@ -131,15 +133,37 @@ function parseLocal(texto: string): AiParseResult {
 
   // Split por newline ou vírgula NÃO seguida de dígito (preserva decimais como "2,5 kg")
   const parts = texto.split(/\n+|,(?!\d)/).map(p => p.trim()).filter(p => p.length > 2)
-  const itens = parts.map(part => {
-    const qtyMatch = part.match(/(\d+[\.,]?\d*)\s*(un|kg|m2|m3|m|l|pc|cx|und|pcs)/i)
+  // Filtrar partes que são apenas stop-words / qualificadores (urgente, normal, etc.)
+  const stopWords = /^(urgente|critica|normal|para\s|na\s|no\s|da\s|do\s|de\s|e\s)/i
+  const itens = parts
+    .filter(p => !stopWords.test(p.trim()) || p.trim().length > 15)
+    .map(part => {
+    // Regex ampliado: reconhece "5 pares de", "10 unidades", "3 metros", etc.
+    const qtyMatch = part.match(/(\d+[\.,]?\d*)\s*(unidades?|und|un|pares?|par|jogos?|jg|metros?|m2|m3|m|kg|ton|litros?|l|pc|pcs|cx|caixas?|rl|rolos?|resmas?)/i)
     let quantidade = 1
     let unidade = 'un'
     if (qtyMatch) {
       quantidade = parseFloat(qtyMatch[1].replace(',', '.'))
-      unidade = qtyMatch[2].toLowerCase()
+      const raw = qtyMatch[2].toLowerCase()
+      // Normalize unit aliases
+      if (/^par/.test(raw)) unidade = 'par'
+      else if (/^jog/.test(raw)) unidade = 'jg'
+      else if (/^metro/.test(raw) || raw === 'm') unidade = 'm'
+      else if (/^litro/.test(raw) || raw === 'l') unidade = 'L'
+      else if (/^caixa/.test(raw) || raw === 'cx') unidade = 'cx'
+      else if (/^rolo/.test(raw) || raw === 'rl') unidade = 'rl'
+      else if (/^resma/.test(raw)) unidade = 'un'
+      else if (/^unid/.test(raw) || raw === 'un' || raw === 'und') unidade = 'un'
+      else unidade = raw
     }
-    let descricao = qtyMatch ? part.replace(qtyMatch[0], '').trim() : part
+    // Also try qty at the start without unit: "5 luvas isolantes..."
+    const qtyOnlyMatch = !qtyMatch ? part.match(/^(\d+)\s+(?!kv|mm|cm|\d)/i) : null
+    if (qtyOnlyMatch) {
+      quantidade = parseInt(qtyOnlyMatch[1])
+    }
+    let descricao = qtyMatch ? part.replace(qtyMatch[0], '').trim() : (qtyOnlyMatch ? part.replace(qtyOnlyMatch[0], '').trim() : part)
+    // Remove leading "de ", "para ", etc. after quantity removal
+    descricao = descricao.replace(/^(de|para|do|da|com|e)\s+/i, '').trim()
     descricao = descricao.replace(/^[\s,\-]+|[\s,\-]+$/g, '') || part
     return { descricao, quantidade, unidade, valor_unitario_estimado: 0 }
   }).filter(i => i.descricao.length > 1)
@@ -152,6 +176,66 @@ function parseLocal(texto: string): AiParseResult {
     comprador_sugerido,
     justificativa_sugerida: `Requisição de ${categoria_sugerida.replace(/_/g, ' ')}`,
     confianca: obra_sugerida ? 0.72 : 0.55,
+  }
+}
+
+// ── Normalize text for matching (remove accents, lowercase) ─────────────────
+function normalize(s: string): string {
+  return s.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().trim()
+}
+
+// ── Match parsed items against est_itens catalog ────────────────────────────
+async function matchCatalogItems(result: AiParseResult): Promise<AiParseResult> {
+  const categoriasEstoque = getCategoriaEstoque(result.categoria_sugerida || '')
+  if (categoriasEstoque.length === 0) return result
+
+  // Fetch all active items for matching categories
+  const { data: catalog } = await supabase
+    .from('est_itens')
+    .select('id, codigo, descricao, unidade, valor_medio')
+    .in('categoria', categoriasEstoque)
+    .eq('ativo', true)
+
+  if (!catalog || catalog.length === 0) return result
+
+  let matchCount = 0
+  const matchedItens = result.itens.map(item => {
+    const normDesc = normalize(item.descricao)
+    // Try to find best match: catalog item whose normalized description contains the search term or vice versa
+    const match = catalog.find(c => {
+      const normCat = normalize(c.descricao)
+      return normCat.includes(normDesc) || normDesc.includes(normCat)
+    })
+    // Also try word-level matching (at least 2 significant words match)
+    const wordMatch = !match ? catalog.find(c => {
+      const normCat = normalize(c.descricao)
+      const words = normDesc.split(/\s+/).filter(w => w.length > 2)
+      const catWords = normCat.split(/\s+/).filter(w => w.length > 2)
+      const commonWords = words.filter(w => catWords.some(cw => cw.includes(w) || w.includes(cw)))
+      return commonWords.length >= 2
+    }) : null
+
+    const best = match || wordMatch
+    if (best) {
+      matchCount++
+      return {
+        ...item,
+        descricao: best.descricao,
+        unidade: (best.unidade || 'UN').toLowerCase(),
+        valor_unitario_estimado: best.valor_medio ?? item.valor_unitario_estimado,
+        est_item_id: best.id,
+        est_item_codigo: best.codigo,
+      }
+    }
+    return item
+  })
+
+  return {
+    ...result,
+    itens: matchedItens,
+    confianca: matchCount > 0
+      ? Math.min(0.95, result.confianca + (matchCount / result.itens.length) * 0.2)
+      : result.confianca,
   }
 }
 
@@ -170,7 +254,8 @@ export function useAiParse() {
       if (n8nUrl) {
         // Tenta o endpoint real de IA (suporta texto + arquivo/imagem)
         try {
-          return await api.parseRequisicaoAi(vars.texto, vars.solicitante_nome, vars.arquivo)
+          const result = await api.parseRequisicaoAi(vars.texto, vars.solicitante_nome, vars.arquivo)
+          return await matchCatalogItems(result)
         } catch {
           // Se tem arquivo binário e n8n falhou, não tem fallback local
           if (vars.arquivo) {
@@ -178,7 +263,8 @@ export function useAiParse() {
           }
           // Cai no parser local se n8n falhar (só texto)
           await new Promise(r => setTimeout(r, 800))
-          return parseLocal(vars.texto)
+          const local = parseLocal(vars.texto)
+          return await matchCatalogItems(local)
         }
       }
 
@@ -189,7 +275,8 @@ export function useAiParse() {
 
       // Usa parser local com delay simulado
       await new Promise(r => setTimeout(r, 1200))
-      return parseLocal(vars.texto)
+      const local = parseLocal(vars.texto)
+      return await matchCatalogItems(local)
     },
   })
 }

--- a/frontend/src/hooks/useEstoque.ts
+++ b/frontend/src/hooks/useEstoque.ts
@@ -5,6 +5,27 @@ import type {
   EstInventario, EstInventarioItem, EstoqueKPIs, NovaMovimentacaoPayload,
 } from '../types/estoque'
 
+// ── Catalog search (for RC item autocomplete) ────────────────────────────────
+export function useItemCatalogSearch(categorias: string[], search: string) {
+  return useQuery<EstItem[]>({
+    queryKey: ['est-itens-catalog', categorias, search],
+    enabled: search.length >= 2 && categorias.length > 0,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('est_itens')
+        .select('id, codigo, descricao, descricao_complementar, categoria, unidade, valor_medio')
+        .in('categoria', categorias)
+        .eq('ativo', true)
+        .ilike('descricao', `%${search}%`)
+        .order('descricao')
+        .limit(10)
+      if (error) return []
+      return (data ?? []) as EstItem[]
+    },
+    staleTime: 30_000,
+  })
+}
+
 // ── Bases ─────────────────────────────────────────────────────────────────────
 export function useBases() {
   return useQuery<EstBase[]>({

--- a/frontend/src/pages/NovaRequisicao.tsx
+++ b/frontend/src/pages/NovaRequisicao.tsx
@@ -11,6 +11,7 @@ import { useAiParse, readFileForAi, isBinaryFile, isImageFile } from '../hooks/u
 import { useCategorias } from '../hooks/useCategorias'
 import { useAuth } from '../contexts/AuthContext'
 import CategoryCard from '../components/CategoryCard'
+import ItemAutocomplete from '../components/ItemAutocomplete'
 import type { RequisicaoItem, Urgencia, AiParseResult, CategoriaMaterial } from '../types'
 
 // ── Obras fixas (alinhadas com seed do SQL) ────────────────────────────────
@@ -834,10 +835,21 @@ export default function NovaRequisicao() {
                 </button>
               )}
             </div>
-            <input required
-              className="w-full border border-slate-200 rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-teal-300 outline-none"
-              placeholder="Descrição do item"
-              value={item.descricao} onChange={e => updateItem(idx, 'descricao', e.target.value)} />
+            <ItemAutocomplete
+              value={item.descricao}
+              onChange={v => updateItem(idx, 'descricao', v)}
+              onSelectCatalog={cat => {
+                setItens(prev => prev.map((it, i) => i === idx ? {
+                  ...it,
+                  descricao: cat.descricao,
+                  unidade: cat.unidade,
+                  valor_unitario_estimado: cat.valor_medio,
+                  est_item_id: cat.id,
+                  est_item_codigo: cat.codigo,
+                } : it))
+              }}
+              categoriaRC={categoria?.codigo ?? ''}
+            />
             <div className="grid grid-cols-3 gap-2">
               <div>
                 <label className="text-[10px] text-slate-400">Qtd</label>
@@ -849,7 +861,7 @@ export default function NovaRequisicao() {
                 <label className="text-[10px] text-slate-400">Unidade</label>
                 <select className="w-full border border-slate-200 rounded-xl px-2 py-1.5 text-sm bg-white focus:ring-2 focus:ring-teal-300 outline-none"
                   value={item.unidade} onChange={e => updateItem(idx, 'unidade', e.target.value)}>
-                  {['un', 'kg', 'm', 'm²', 'm³', 'L', 'pc', 'cx', 'hr', 'vb'].map(u => <option key={u} value={u}>{u}</option>)}
+                  {['un', 'par', 'jg', 'kg', 'ton', 'm', 'm²', 'm³', 'L', 'pc', 'cx', 'rl', 'hr', 'vb'].map(u => <option key={u} value={u}>{u}</option>)}
                 </select>
               </div>
               <div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -74,6 +74,8 @@ export interface RequisicaoItem {
   quantidade: number
   unidade: string
   valor_unitario_estimado: number
+  est_item_id?: string
+  est_item_codigo?: string
 }
 
 export interface Requisicao {


### PR DESCRIPTION
## Summary
- Replace free-text item input in Nova Requisição Step 2 with an autocomplete that searches `est_itens` filtered by the selected RC category, auto-filling unit and average price on selection
- Add inline "Cadastrar novo item" form (admin=direct insert, non-admin=pre-cadastro for approval)
- Improve AI parser with `matchCatalogItems()` for automatic catalog matching (confidence jumps from ~72% to 92%) and expanded local parser regex for quantities/units

## Test plan
- [ ] Navigate to `/nova`, select "EPI e EPC", advance to Step 2, type "luva" → verify dropdown shows catalog items with code, description, unit (PR), price
- [ ] Select "Luva isolante classe 00 (500V)" → verify unit auto-fills as "par" and price as 185
- [ ] Type non-matching text → verify "Nenhum item encontrado" message and "+ Cadastrar novo item" button appear
- [ ] Click "+ Cadastrar novo item" → verify inline form with description pre-filled, unit selector, and Criar button
- [ ] Use AI assistant with "5 pares de luva isolante classe 2 17kV, 10 capacetes com jugular" → verify items match catalog with correct quantities and prices
- [ ] Select a category without stock mapping (e.g., Serviços) → verify plain text input is shown instead of autocomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)