### PR TITLE
fix(frotas): align all Frotas pages to teal design system

### DIFF
--- a/frontend/src/pages/frotas/Abastecimentos.tsx
+++ b/frontend/src/pages/frotas/Abastecimentos.tsx
@@ -49,9 +49,10 @@ function NovoAbastecimentoModal({ onClose, isLight }: { onClose: () => void; isL
     onClose()
   }
 
-  const inp = `w-full px-3 py-2 rounded-xl text-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-rose-500/30 ${
-    isLight ? 'bg-slate-50 border border-slate-200 text-slate-800' : 'bg-white/6 border border-white/10 text-white'
+  const inp = `w-full px-3 py-2 rounded-xl text-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40 ${
+    isLight ? 'bg-white border border-slate-200 shadow-sm text-slate-800 hover:border-slate-300' : 'bg-white/6 border border-white/12 text-white hover:border-white/20'
   }`
+  const lbl = 'block text-xs font-medium mb-1 ' + (isLight ? 'text-slate-600' : 'text-slate-300')
   const sel = inp + (isLight ? '' : ' [&>option]:bg-slate-900')
 
   return (
@@ -61,7 +62,7 @@ function NovoAbastecimentoModal({ onClose, isLight }: { onClose: () => void; isL
 
         <div className="grid grid-cols-2 gap-3">
           <div>
-            <label className="text-[11px] text-slate-400">Veiculo *</label>
+            <label className={lbl}>Veiculo *</label>
             <select className={sel} value={form.veiculo_id} onChange={e => setForm(f => ({ ...f, veiculo_id: e.target.value }))} required>
               <option value="">Selecione...</option>
               {veiculos.filter(v => v.status !== 'baixado').map(v => (
@@ -70,18 +71,18 @@ function NovoAbastecimentoModal({ onClose, isLight }: { onClose: () => void; isL
             </select>
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">Data *</label>
+            <label className={lbl}>Data *</label>
             <input type="date" className={inp} value={form.data_abastecimento} onChange={e => setForm(f => ({ ...f, data_abastecimento: e.target.value }))} required />
           </div>
         </div>
 
         <div className="grid grid-cols-2 gap-3">
           <div>
-            <label className="text-[11px] text-slate-400">Posto</label>
+            <label className={lbl}>Posto</label>
             <input className={inp} value={form.posto} onChange={e => setForm(f => ({ ...f, posto: e.target.value }))} placeholder="Nome do posto" />
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">Combustivel</label>
+            <label className={lbl}>Combustivel</label>
             <select className={sel} value={form.combustivel} onChange={e => setForm(f => ({ ...f, combustivel: e.target.value as CombustivelVeiculo }))}>
               {Object.entries(COMB_LABEL).map(([k, v]) => <option key={k} value={k}>{v}</option>)}
             </select>
@@ -90,15 +91,15 @@ function NovoAbastecimentoModal({ onClose, isLight }: { onClose: () => void; isL
 
         <div className="grid grid-cols-3 gap-3">
           <div>
-            <label className="text-[11px] text-slate-400">Hodometro (km) *</label>
+            <label className={lbl}>Hodometro (km) *</label>
             <input type="number" className={inp} value={form.hodometro} onChange={e => setForm(f => ({ ...f, hodometro: e.target.value }))} required placeholder="55432" />
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">Litros *</label>
+            <label className={lbl}>Litros *</label>
             <input type="number" className={inp} step="0.001" value={form.litros} onChange={e => setForm(f => ({ ...f, litros: e.target.value }))} required placeholder="40.000" />
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">R$/litro *</label>
+            <label className={lbl}>R$/litro *</label>
             <input type="number" className={inp} step="0.001" value={form.valor_litro} onChange={e => setForm(f => ({ ...f, valor_litro: e.target.value }))} required placeholder="5.890" />
           </div>
         </div>
@@ -113,22 +114,22 @@ function NovoAbastecimentoModal({ onClose, isLight }: { onClose: () => void; isL
 
         <div className="grid grid-cols-2 gap-3">
           <div>
-            <label className="text-[11px] text-slate-400">Forma de pagamento</label>
+            <label className={lbl}>Forma de pagamento</label>
             <select className={sel} value={form.forma_pagamento} onChange={e => setForm(f => ({ ...f, forma_pagamento: e.target.value as TipoPagamento }))}>
               {Object.entries(PAG_LABEL).map(([k, v]) => <option key={k} value={k}>{v}</option>)}
             </select>
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">No do cupom</label>
+            <label className={lbl}>No do cupom</label>
             <input className={inp} value={form.numero_cupom} onChange={e => setForm(f => ({ ...f, numero_cupom: e.target.value }))} placeholder="0000001" />
           </div>
         </div>
 
         <div className="flex gap-2">
-          <button type="button" onClick={onClose} className={`flex-1 py-2 rounded-xl border text-sm ${
+          <button type="button" onClick={onClose} className={`flex-1 font-medium py-2.5 rounded-xl border text-sm ${
             isLight ? 'border-slate-200 text-slate-500 hover:bg-slate-50' : 'border-white/10 text-slate-400 hover:bg-white/5'
           }`}>Cancelar</button>
-          <button type="submit" disabled={registrar.isPending} className="flex-1 py-2 rounded-xl bg-rose-600 hover:bg-rose-500 text-sm text-white font-semibold disabled:opacity-50">
+          <button type="submit" disabled={registrar.isPending} className="flex-1 py-2.5 rounded-xl bg-gradient-to-r from-teal-500 to-teal-600 hover:from-teal-400 hover:to-teal-500 shadow-sm shadow-teal-500/20 text-sm text-white font-semibold disabled:opacity-50">
             {registrar.isPending ? 'Registrando...' : 'Registrar'}
           </button>
         </div>
@@ -162,11 +163,11 @@ export default function Abastecimentos() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className={`text-xl font-bold flex items-center gap-2 ${isLight ? 'text-slate-800' : 'text-white'}`}>
-            <Fuel size={20} className="text-rose-400" /> Abastecimentos
+            <Fuel size={20} className="text-teal-500" /> Abastecimentos
           </h1>
           <p className="text-sm text-slate-500">{abastecimentos.length} registros no mes</p>
         </div>
-        <button onClick={() => setModal(true)} className="flex items-center gap-2 px-4 py-2 rounded-xl bg-rose-600 hover:bg-rose-500 text-sm text-white font-semibold">
+        <button onClick={() => setModal(true)} className="flex items-center gap-2 px-4 py-2 rounded-xl bg-gradient-to-r from-teal-500 to-teal-600 hover:from-teal-400 hover:to-teal-500 shadow-sm shadow-teal-500/20 text-sm text-white font-semibold">
           <Plus size={15} /> Registrar
         </button>
       </div>
@@ -176,7 +177,7 @@ export default function Abastecimentos() {
         <div>
           <label className="text-[10px] text-slate-500 block mb-1">Mes</label>
           <input type="month" value={mesFiltro} onChange={e => setMesFiltro(e.target.value)}
-            className={`px-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-rose-500/30 ${
+            className={`px-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-teal-400/40 ${
               isLight ? 'bg-slate-50 border border-slate-200 text-slate-800' : 'bg-white/6 border border-white/10 text-white'
             }`} />
         </div>
@@ -185,7 +186,7 @@ export default function Abastecimentos() {
           <select
             value={veiculoFiltro}
             onChange={e => setVeiculoFiltro(e.target.value)}
-            className={`px-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-rose-500/30 ${
+            className={`px-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-teal-400/40 ${
               isLight ? 'bg-slate-50 border border-slate-200 text-slate-800' : 'bg-white/6 border border-white/10 text-white [&>option]:bg-slate-900'
             }`}
           >
@@ -199,7 +200,7 @@ export default function Abastecimentos() {
 
       {/* KPI Cards */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-        <div className="glass-card rounded-xl p-3 border-l-4 border-l-rose-500">
+        <div className="glass-card rounded-xl p-3 border-l-4 border-l-teal-500">
           <p className="text-[10px] text-slate-500 uppercase mb-1">Custo Total</p>
           <p className={`text-lg font-black ${isLight ? 'text-slate-800' : 'text-white'}`}>{BRL(totalCusto)}</p>
         </div>

--- a/frontend/src/pages/frotas/Checklists.tsx
+++ b/frontend/src/pages/frotas/Checklists.tsx
@@ -55,9 +55,10 @@ function NovaChecklistModal({ onClose, isLight }: { onClose: () => void; isLight
     onClose()
   }
 
-  const inp = `w-full px-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-rose-500/30 ${
-    isLight ? 'bg-slate-50 border border-slate-200 text-slate-800' : 'bg-white/6 border border-white/10 text-white'
+  const inp = `w-full px-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-teal-400/40 ${
+    isLight ? 'bg-white border border-slate-200 shadow-sm text-slate-800 hover:border-slate-300' : 'bg-white/6 border border-white/12 text-white hover:border-white/20'
   }`
+  const lbl = 'block text-xs font-medium mb-1 ' + (isLight ? 'text-slate-600' : 'text-slate-300')
   const sel = inp + (isLight ? '' : ' [&>option]:bg-slate-900')
 
   return (
@@ -67,7 +68,7 @@ function NovaChecklistModal({ onClose, isLight }: { onClose: () => void; isLight
 
         <div className="grid grid-cols-2 gap-3">
           <div>
-            <label className="text-[11px] text-slate-400">Veiculo *</label>
+            <label className={lbl}>Veiculo *</label>
             <select className={sel} value={form.veiculo_id} onChange={e => setForm(f => ({ ...f, veiculo_id: e.target.value }))} required>
               <option value="">Selecione...</option>
               {veiculos.filter(v => v.status !== 'baixado').map(v => (
@@ -76,7 +77,7 @@ function NovaChecklistModal({ onClose, isLight }: { onClose: () => void; isLight
             </select>
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">Tipo</label>
+            <label className={lbl}>Tipo</label>
             <select className={sel} value={form.tipo} onChange={e => setForm(f => ({ ...f, tipo: e.target.value as TipoChecklist }))}>
               {Object.entries(TIPO_LABEL).map(([k, v]) => <option key={k} value={k}>{v}</option>)}
             </select>
@@ -84,13 +85,13 @@ function NovaChecklistModal({ onClose, isLight }: { onClose: () => void; isLight
         </div>
 
         <div>
-          <label className="text-[11px] text-slate-400">Hodometro atual (km)</label>
+          <label className={lbl}>Hodometro atual (km)</label>
           <input type="number" className={inp} value={form.hodometro} onChange={e => setForm(f => ({ ...f, hodometro: e.target.value }))} placeholder="Ex: 55432" />
         </div>
 
         {/* Itens */}
         <div className="space-y-2">
-          <label className="text-[11px] text-slate-400 uppercase tracking-wider">Itens de Verificacao</label>
+          <label className={lbl + ' uppercase tracking-wider'}>Itens de Verificacao</label>
           {ITENS_CHECKLIST.map(item => (
             <button
               key={item.key}
@@ -122,15 +123,15 @@ function NovaChecklistModal({ onClose, isLight }: { onClose: () => void; isLight
         </div>
 
         <div>
-          <label className="text-[11px] text-slate-400">Observacoes</label>
+          <label className={lbl}>Observacoes</label>
           <textarea className={inp + ' resize-none'} rows={2} value={form.observacoes} onChange={e => setForm(f => ({ ...f, observacoes: e.target.value }))} placeholder="Anomalias, observacoes adicionais..." />
         </div>
 
         <div className="flex gap-2">
-          <button type="button" onClick={onClose} className={`flex-1 py-2 rounded-xl border text-sm ${
+          <button type="button" onClick={onClose} className={`flex-1 py-2.5 rounded-xl border text-sm font-medium ${
             isLight ? 'border-slate-200 text-slate-500 hover:bg-slate-50' : 'border-white/10 text-slate-400 hover:bg-white/5'
           }`}>Cancelar</button>
-          <button type="submit" disabled={criar.isPending || !form.veiculo_id} className="flex-1 py-2 rounded-xl bg-rose-600 hover:bg-rose-500 text-sm text-white font-semibold disabled:opacity-50">
+          <button type="submit" disabled={criar.isPending || !form.veiculo_id} className="flex-1 py-2 rounded-xl bg-gradient-to-r from-teal-500 to-teal-600 hover:from-teal-400 hover:to-teal-500 shadow-sm shadow-teal-500/20 text-sm text-white font-semibold disabled:opacity-50">
             {criar.isPending ? 'Registrando...' : 'Registrar Checklist'}
           </button>
         </div>
@@ -191,13 +192,13 @@ export default function Checklists() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className={`text-xl font-bold flex items-center gap-2 ${isLight ? 'text-slate-800' : 'text-white'}`}>
-            <ClipboardCheck size={20} className="text-rose-400" /> Checklists
+            <ClipboardCheck size={20} className="text-teal-500" /> Checklists
           </h1>
           <p className="text-sm text-slate-500">
             {liberados} liberados · <span className="text-red-400">{naoLiberados} nao liberados</span>
           </p>
         </div>
-        <button onClick={() => setModal(true)} className="flex items-center gap-2 px-4 py-2 rounded-xl bg-rose-600 hover:bg-rose-500 text-sm text-white font-semibold">
+        <button onClick={() => setModal(true)} className="flex items-center gap-2 px-4 py-2 rounded-xl bg-gradient-to-r from-teal-500 to-teal-600 hover:from-teal-400 hover:to-teal-500 shadow-sm shadow-teal-500/20 text-sm text-white font-semibold">
           <Plus size={15} /> Novo Checklist
         </button>
       </div>
@@ -205,22 +206,22 @@ export default function Checklists() {
       {/* Filtros */}
       <div className="flex gap-3 flex-wrap">
         <div>
-          <label className="text-[10px] text-slate-500 block mb-1">Data</label>
+          <label className="text-xs font-medium text-slate-500 block mb-1">Data</label>
           <input
             type="date"
             value={dataFiltro}
             onChange={e => setDataFiltro(e.target.value)}
-            className={`px-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-rose-500/30 ${
+            className={`px-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-teal-400/40 ${
               isLight ? 'bg-slate-50 border border-slate-200 text-slate-800' : 'bg-white/6 border border-white/10 text-white'
             }`}
           />
         </div>
         <div>
-          <label className="text-[10px] text-slate-500 block mb-1">Tipo</label>
+          <label className="text-xs font-medium text-slate-500 block mb-1">Tipo</label>
           <select
             value={tipoFiltro}
             onChange={e => setTipoFiltro(e.target.value as TipoChecklist | '')}
-            className={`px-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-rose-500/30 ${
+            className={`px-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-teal-400/40 ${
               isLight ? 'bg-slate-50 border border-slate-200 text-slate-800' : 'bg-white/6 border border-white/10 text-white [&>option]:bg-slate-900'
             }`}
           >

--- a/frontend/src/pages/frotas/FrotasHome.tsx
+++ b/frontend/src/pages/frotas/FrotasHome.tsx
@@ -23,17 +23,28 @@ const STATUS_VEICULO_DOT: Record<string, string> = {
 }
 
 // ── KPI Card ──────────────────────────────────────────────────────────────────
+const ACCENT_BORDER: Record<string, string> = {
+  teal: 'border-l-teal-500',
+  emerald: 'border-l-emerald-500',
+  orange: 'border-l-orange-500',
+  amber: 'border-l-amber-500',
+  red: 'border-l-red-500',
+  blue: 'border-l-blue-500',
+  violet: 'border-l-violet-500',
+  rose: 'border-l-rose-500',
+}
+
 function KpiCard({
-  label, value, sub, accent = 'rose', warn = false, isLight = false,
+  label, value, sub, accent = 'teal', warn = false, isLight = false,
 }: {
   label: string; value: string | number; sub?: string; accent?: string; warn?: boolean; isLight?: boolean
 }) {
-  const border = warn ? 'border-l-red-500' : `border-l-${accent}-500`
+  const border = warn ? 'border-l-red-500' : (ACCENT_BORDER[accent] ?? 'border-l-teal-500')
   return (
     <div className={`glass-card rounded-2xl p-4 border-l-4 ${border}`}>
-      <p className="text-[11px] text-slate-500 uppercase tracking-wider mb-1">{label}</p>
+      <p className="text-xs text-slate-500 uppercase tracking-wider mb-1">{label}</p>
       <p className={`text-2xl font-black ${isLight ? 'text-slate-800' : 'text-white'}`}>{value}</p>
-      {sub && <p className="text-[11px] text-slate-500 mt-0.5">{sub}</p>}
+      {sub && <p className="text-xs text-slate-500 mt-0.5">{sub}</p>}
     </div>
   )
 }
@@ -96,7 +107,7 @@ export default function FrotasHome() {
       ) : (
         <>
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-            <KpiCard label="Total da Frota"    value={k?.total_veiculos ?? 0} sub={`${k?.disponiveis ?? 0} disponiveis`} accent="rose" isLight={isLight} />
+            <KpiCard label="Total da Frota"    value={k?.total_veiculos ?? 0} sub={`${k?.disponiveis ?? 0} disponiveis`} accent="teal" isLight={isLight} />
             <KpiCard label="Disponibilidade"   value={`${k?.taxa_disponibilidade ?? 0}%`} sub={`${k?.em_uso ?? 0} em uso`} accent="emerald" isLight={isLight} />
             <KpiCard label="OS Abertas"        value={k?.os_abertas ?? 0} sub={`${k?.os_criticas ?? 0} criticas`} accent="orange" warn={(k?.os_criticas ?? 0) > 0} isLight={isLight} />
             <KpiCard label="Em Manutencao"     value={(k?.em_manutencao ?? 0) + (k?.bloqueados ?? 0)} sub={`${k?.bloqueados ?? 0} bloqueados`} accent="amber" isLight={isLight} />
@@ -105,7 +116,7 @@ export default function FrotasHome() {
           <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
             <KpiCard label="Prev. Vencidas"    value={k?.preventivas_vencidas ?? 0} sub="atencao imediata" accent="red" warn={(k?.preventivas_vencidas ?? 0) > 0} isLight={isLight} />
             <KpiCard label="Prev. em 7 dias"   value={k?.preventivas_proximas_7d ?? 0} sub="programar" accent="amber" isLight={isLight} />
-            <KpiCard label="Custo Manutencao"  value={BRL(k?.custo_manutencao_mes ?? 0)} sub="mes atual" accent="rose" isLight={isLight} />
+            <KpiCard label="Custo Manutencao"  value={BRL(k?.custo_manutencao_mes ?? 0)} sub="mes atual" accent="teal" isLight={isLight} />
             <KpiCard label="Custo Abastecimento" value={BRL(k?.custo_abastecimento_mes ?? 0)} sub="mes atual" accent="blue" isLight={isLight} />
             <KpiCard label="Ocorrencias" value={k?.ocorrencias_abertas ?? 0} sub="pendentes" accent="violet" warn={(k?.ocorrencias_abertas ?? 0) > 0} isLight={isLight} />
           </div>
@@ -117,7 +128,7 @@ export default function FrotasHome() {
         <div className="glass-card rounded-2xl p-4">
           <div className="flex items-center justify-between mb-3">
             <h2 className={`text-sm font-semibold flex items-center gap-2 ${isLight ? 'text-slate-800' : 'text-white'}`}>
-              <Car size={15} className="text-rose-400" />
+              <Car size={15} className="text-teal-500" />
               Status da Frota
             </h2>
             <div className="flex items-center gap-3 text-[10px] text-slate-500">
@@ -189,10 +200,10 @@ export default function FrotasHome() {
         {/* Ocorrencias Telemetria */}
         <div className="glass-card rounded-2xl p-4 space-y-2">
           <h2 className={`text-sm font-semibold flex items-center gap-2 mb-3 ${isLight ? 'text-slate-800' : 'text-white'}`}>
-            <Radio size={15} className="text-rose-400" />
+            <Radio size={15} className="text-teal-500" />
             Ocorrencias Pendentes
             {otelPendentes.length > 0 && (
-              <span className="ml-auto text-[10px] bg-rose-500/15 text-rose-300 border border-rose-500/30 px-2 py-0.5 rounded-full">
+              <span className="ml-auto text-[10px] bg-red-500/15 text-red-300 border border-red-500/30 px-2 py-0.5 rounded-full">
                 {otelPendentes.length}
               </span>
             )}

--- a/frontend/src/pages/frotas/Telemetria.tsx
+++ b/frontend/src/pages/frotas/Telemetria.tsx
@@ -95,10 +95,10 @@ function OcorrenciaModal({ oc, onClose, isLight }: { oc: FroOcorrenciaTel; onClo
 
         {/* Observacoes */}
         <div>
-          <label className="text-[11px] text-slate-400">Observacoes / Tratativa</label>
+          <label className={`block text-xs font-medium mb-1 ${isLight ? 'text-slate-600' : 'text-slate-300'}`}>Observacoes / Tratativa</label>
           <textarea
-            className={`w-full px-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-rose-500/30 resize-none mt-1 ${
-              isLight ? 'bg-slate-50 border border-slate-200 text-slate-800' : 'bg-white/6 border border-white/10 text-white'
+            className={`w-full px-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-teal-400/40 resize-none mt-1 ${
+              isLight ? 'bg-white border border-slate-200 shadow-sm text-slate-800' : 'bg-white/6 border border-white/12 text-white'
             }`}
             rows={3}
             value={observacoes}
@@ -108,7 +108,7 @@ function OcorrenciaModal({ oc, onClose, isLight }: { oc: FroOcorrenciaTel; onClo
         </div>
 
         <div className="flex gap-2">
-          <button onClick={onClose} className={`flex-1 py-2 rounded-xl border text-sm ${
+          <button onClick={onClose} className={`flex-1 font-medium py-2.5 rounded-xl border text-sm ${
             isLight ? 'border-slate-200 text-slate-500 hover:bg-slate-50' : 'border-white/10 text-slate-400 hover:bg-white/5'
           }`}>Fechar</button>
           {oc.status !== 'encerrada' && (
@@ -177,8 +177,9 @@ function NovaOcorrenciaModal({ onClose, isLight }: { onClose: () => void; isLigh
     onClose()
   }
 
-  const inp = `w-full px-3 py-2 rounded-xl text-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-rose-500/30 ${
-    isLight ? 'bg-slate-50 border border-slate-200 text-slate-800' : 'bg-white/6 border border-white/10 text-white'
+  const lbl = 'block text-xs font-medium mb-1 ' + (isLight ? 'text-slate-600' : 'text-slate-300')
+  const inp = `w-full px-3 py-2 rounded-xl text-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40 ${
+    isLight ? 'bg-white border border-slate-200 shadow-sm text-slate-800' : 'bg-white/6 border border-white/12 text-white'
   }`
   const sel = inp + (isLight ? '' : ' [&>option]:bg-slate-900')
 
@@ -189,7 +190,7 @@ function NovaOcorrenciaModal({ onClose, isLight }: { onClose: () => void; isLigh
 
         <div className="grid grid-cols-2 gap-3">
           <div>
-            <label className="text-[11px] text-slate-400">Veiculo *</label>
+            <label className={lbl}>Veiculo *</label>
             <select className={sel} value={form.veiculo_id} onChange={e => setForm(f => ({ ...f, veiculo_id: e.target.value }))} required>
               <option value="">Selecione...</option>
               {veiculos.filter(v => v.status !== 'baixado').map(v => (
@@ -198,7 +199,7 @@ function NovaOcorrenciaModal({ onClose, isLight }: { onClose: () => void; isLigh
             </select>
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">Tipo *</label>
+            <label className={lbl}>Tipo *</label>
             <select className={sel} value={form.tipo_ocorrencia} onChange={e => setForm(f => ({ ...f, tipo_ocorrencia: e.target.value as TipoOcorrenciaTel }))}>
               {Object.entries(TIPO_CFG).map(([k, v]) => <option key={k} value={k}>{v.label}</option>)}
             </select>
@@ -207,30 +208,30 @@ function NovaOcorrenciaModal({ onClose, isLight }: { onClose: () => void; isLigh
 
         <div className="grid grid-cols-2 gap-3">
           <div>
-            <label className="text-[11px] text-slate-400">Data/hora *</label>
+            <label className={lbl}>Data/hora *</label>
             <input type="datetime-local" className={inp} value={form.data_ocorrencia} onChange={e => setForm(f => ({ ...f, data_ocorrencia: e.target.value }))} required />
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">Velocidade (km/h)</label>
+            <label className={lbl}>Velocidade (km/h)</label>
             <input type="number" className={inp} value={form.velocidade} onChange={e => setForm(f => ({ ...f, velocidade: e.target.value }))} placeholder="Ex: 120" />
           </div>
         </div>
 
         <div>
-          <label className="text-[11px] text-slate-400">Endereco / Local</label>
+          <label className={lbl}>Endereco / Local</label>
           <input className={inp} value={form.endereco} onChange={e => setForm(f => ({ ...f, endereco: e.target.value }))} placeholder="Rodovia BR-040, km 512" />
         </div>
 
         <div>
-          <label className="text-[11px] text-slate-400">Observacoes</label>
+          <label className={lbl}>Observacoes</label>
           <textarea className={inp + ' resize-none'} rows={2} value={form.observacoes} onChange={e => setForm(f => ({ ...f, observacoes: e.target.value }))} placeholder="Detalhes adicionais..." />
         </div>
 
         <div className="flex gap-2">
-          <button type="button" onClick={onClose} className={`flex-1 py-2 rounded-xl border text-sm ${
+          <button type="button" onClick={onClose} className={`flex-1 font-medium py-2.5 rounded-xl border text-sm ${
             isLight ? 'border-slate-200 text-slate-500 hover:bg-slate-50' : 'border-white/10 text-slate-400 hover:bg-white/5'
           }`}>Cancelar</button>
-          <button type="submit" disabled={registrar.isPending} className="flex-1 py-2 rounded-xl bg-rose-600 hover:bg-rose-500 text-sm text-white font-semibold disabled:opacity-50">
+          <button type="submit" disabled={registrar.isPending} className="flex-1 py-2 rounded-xl bg-gradient-to-r from-teal-500 to-teal-600 hover:from-teal-400 hover:to-teal-500 shadow-sm shadow-teal-500/20 text-sm text-white font-semibold disabled:opacity-50">
             {registrar.isPending ? 'Registrando...' : 'Registrar'}
           </button>
         </div>
@@ -261,11 +262,11 @@ export default function Telemetria() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className={`text-xl font-bold flex items-center gap-2 ${isLight ? 'text-slate-800' : 'text-white'}`}>
-            <Radio size={20} className="text-rose-400" /> Telemetria e Compliance
+            <Radio size={20} className="text-teal-500" /> Telemetria e Compliance
           </h1>
           <p className="text-sm text-slate-500">Ocorrencias registradas pelo sistema de rastreamento</p>
         </div>
-        <button onClick={() => setNovaModal(true)} className="flex items-center gap-2 px-4 py-2 rounded-xl bg-rose-600 hover:bg-rose-500 text-sm text-white font-semibold">
+        <button onClick={() => setNovaModal(true)} className="flex items-center gap-2 px-4 py-2 rounded-xl bg-gradient-to-r from-teal-500 to-teal-600 hover:from-teal-400 hover:to-teal-500 shadow-sm shadow-teal-500/20 text-sm text-white font-semibold">
           <Plus size={15} /> Registrar Ocorrencia
         </button>
       </div>
@@ -280,7 +281,7 @@ export default function Telemetria() {
             onClick={() => setTabIdx(i)}
             className={`px-3 py-1.5 rounded-lg text-xs font-semibold transition-all ${
               tabIdx === i
-                ? 'bg-rose-600 text-white'
+                ? 'bg-teal-600 text-white'
                 : isLight
                   ? 'text-slate-500 hover:text-slate-800'
                   : 'text-slate-400 hover:text-white'
@@ -296,7 +297,7 @@ export default function Telemetria() {
         <span>Fluxo:</span>
         {['Registrada', 'Analisada', 'Comunicado RH', 'Encerrada'].map((s, i, arr) => (
           <span key={s} className="flex items-center gap-1">
-            <span className={`px-1.5 py-0.5 rounded ${i === tabIdx ? 'text-rose-300 bg-rose-500/15' : ''}`}>{s}</span>
+            <span className={`px-1.5 py-0.5 rounded ${i === tabIdx ? 'text-teal-300 bg-teal-500/15' : ''}`}>{s}</span>
             {i < arr.length - 1 && <span>→</span>}
           </span>
         ))}

--- a/frontend/src/pages/frotas/Veiculos.tsx
+++ b/frontend/src/pages/frotas/Veiculos.tsx
@@ -60,10 +60,12 @@ function VeiculoModal({
     onClose()
   }
 
-  const inp = `w-full px-3 py-2 rounded-xl text-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-rose-500/30 ${
+  const lbl = 'block text-xs font-medium mb-1 ' + (isLight ? 'text-slate-600' : 'text-slate-300')
+
+  const inp = `w-full px-3 py-2 rounded-xl text-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40 ${
     isLight
-      ? 'bg-slate-50 border border-slate-200 text-slate-800 focus:border-rose-400/50'
-      : 'bg-white/6 border border-white/10 text-white focus:border-rose-400/50'
+      ? 'bg-white border border-slate-200 shadow-sm text-slate-800 hover:border-slate-300'
+      : 'bg-white/6 border border-white/12 text-white hover:border-white/20'
   }`
   const sel = inp + (isLight ? '' : ' [&>option]:bg-slate-900')
 
@@ -78,15 +80,15 @@ function VeiculoModal({
         {/* Linha 1 */}
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
           <div>
-            <label className="text-[11px] text-slate-400">Placa *</label>
+            <label className={lbl}>Placa *</label>
             <input className={inp} value={form.placa} onChange={e => set('placa', e.target.value.toUpperCase())} required placeholder="ABC-1234" />
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">Renavam</label>
+            <label className={lbl}>Renavam</label>
             <input className={inp} value={form.renavam ?? ''} onChange={e => set('renavam', e.target.value)} placeholder="00000000000" />
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">Status</label>
+            <label className={lbl}>Status</label>
             <select className={sel} value={form.status} onChange={e => set('status', e.target.value)}>
               {Object.entries(STATUS_CFG).map(([k, v]) => <option key={k} value={k}>{v.label}</option>)}
             </select>
@@ -96,11 +98,11 @@ function VeiculoModal({
         {/* Linha 2 */}
         <div className="grid grid-cols-2 gap-3">
           <div>
-            <label className="text-[11px] text-slate-400">Marca *</label>
+            <label className={lbl}>Marca *</label>
             <input className={inp} value={form.marca} onChange={e => set('marca', e.target.value)} required placeholder="Toyota" />
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">Modelo *</label>
+            <label className={lbl}>Modelo *</label>
             <input className={inp} value={form.modelo} onChange={e => set('modelo', e.target.value)} required placeholder="Hilux" />
           </div>
         </div>
@@ -108,15 +110,15 @@ function VeiculoModal({
         {/* Linha 3 */}
         <div className="grid grid-cols-3 gap-3">
           <div>
-            <label className="text-[11px] text-slate-400">Ano Fab.</label>
+            <label className={lbl}>Ano Fab.</label>
             <input type="number" className={inp} value={form.ano_fab ?? ''} onChange={e => set('ano_fab', +e.target.value)} placeholder="2022" />
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">Ano Mod.</label>
+            <label className={lbl}>Ano Mod.</label>
             <input type="number" className={inp} value={form.ano_mod ?? ''} onChange={e => set('ano_mod', +e.target.value)} placeholder="2023" />
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">Cor</label>
+            <label className={lbl}>Cor</label>
             <input className={inp} value={form.cor ?? ''} onChange={e => set('cor', e.target.value)} placeholder="Branca" />
           </div>
         </div>
@@ -124,19 +126,19 @@ function VeiculoModal({
         {/* Linha 4 */}
         <div className="grid grid-cols-3 gap-3">
           <div>
-            <label className="text-[11px] text-slate-400">Categoria</label>
+            <label className={lbl}>Categoria</label>
             <select className={sel} value={form.categoria} onChange={e => set('categoria', e.target.value as CategoriaVeiculo)}>
               {Object.entries(CATEGORIA_LABEL).map(([k, v]) => <option key={k} value={k}>{v}</option>)}
             </select>
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">Combustivel</label>
+            <label className={lbl}>Combustivel</label>
             <select className={sel} value={form.combustivel} onChange={e => set('combustivel', e.target.value as CombustivelVeiculo)}>
               {Object.entries(COMBUSTIVEL_LABEL).map(([k, v]) => <option key={k} value={k}>{v}</option>)}
             </select>
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">Propriedade</label>
+            <label className={lbl}>Propriedade</label>
             <select className={sel} value={form.propriedade} onChange={e => set('propriedade', e.target.value as PropriedadeVeiculo)}>
               <option value="propria">Propria</option>
               <option value="locada">Locada</option>
@@ -148,15 +150,15 @@ function VeiculoModal({
         {/* Hodometro */}
         <div className="grid grid-cols-3 gap-3">
           <div>
-            <label className="text-[11px] text-slate-400">Hodometro atual (km)</label>
+            <label className={lbl}>Hodometro atual (km)</label>
             <input type="number" className={inp} value={form.hodometro_atual} onChange={e => set('hodometro_atual', +e.target.value)} />
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">Proxima prev. (km)</label>
+            <label className={lbl}>Proxima prev. (km)</label>
             <input type="number" className={inp} value={form.km_proxima_preventiva ?? ''} onChange={e => set('km_proxima_preventiva', +e.target.value)} placeholder="55000" />
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">Proxima prev. (data)</label>
+            <label className={lbl}>Proxima prev. (data)</label>
             <input type="date" className={inp} value={form.data_proxima_preventiva ?? ''} onChange={e => set('data_proxima_preventiva', e.target.value)} />
           </div>
         </div>
@@ -164,31 +166,31 @@ function VeiculoModal({
         {/* Documentos */}
         <div className="grid grid-cols-3 gap-3">
           <div>
-            <label className="text-[11px] text-slate-400">Venc. CRLV</label>
+            <label className={lbl}>Venc. CRLV</label>
             <input type="date" className={inp} value={form.vencimento_crlv ?? ''} onChange={e => set('vencimento_crlv', e.target.value)} />
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">Venc. Seguro</label>
+            <label className={lbl}>Venc. Seguro</label>
             <input type="date" className={inp} value={form.vencimento_seguro ?? ''} onChange={e => set('vencimento_seguro', e.target.value)} />
           </div>
           <div>
-            <label className="text-[11px] text-slate-400">Venc. Tacografo</label>
+            <label className={lbl}>Venc. Tacografo</label>
             <input type="date" className={inp} value={form.vencimento_tacografo ?? ''} onChange={e => set('vencimento_tacografo', e.target.value)} />
           </div>
         </div>
 
         <div>
-          <label className="text-[11px] text-slate-400">Observacoes</label>
+          <label className={lbl}>Observacoes</label>
           <textarea className={inp + ' resize-none'} rows={2} value={form.observacoes ?? ''} onChange={e => set('observacoes', e.target.value)} />
         </div>
 
         <div className="flex gap-2 pt-2">
-          <button type="button" onClick={onClose} className={`flex-1 py-2 rounded-xl border text-sm ${
-            isLight ? 'border-slate-200 text-slate-500 hover:bg-slate-50' : 'border-white/10 text-slate-400 hover:bg-white/5'
+          <button type="button" onClick={onClose} className={`flex-1 py-2.5 rounded-xl border text-sm font-medium transition-colors ${
+            isLight ? 'border-slate-200 text-slate-500 hover:bg-slate-50 hover:border-slate-300' : 'border-white/10 text-slate-400 hover:bg-white/5 hover:border-white/20'
           }`}>
             Cancelar
           </button>
-          <button type="submit" disabled={salvar.isPending} className="flex-1 py-2 rounded-xl bg-rose-600 hover:bg-rose-500 text-sm text-white font-semibold disabled:opacity-50">
+          <button type="submit" disabled={salvar.isPending} className="flex-1 py-2.5 rounded-xl bg-gradient-to-r from-teal-500 to-teal-600 hover:from-teal-400 hover:to-teal-500 shadow-sm shadow-teal-500/20 text-sm text-white font-semibold disabled:opacity-50">
             {salvar.isPending ? 'Salvando...' : 'Salvar'}
           </button>
         </div>
@@ -225,13 +227,13 @@ export default function Veiculos() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className={`text-xl font-bold flex items-center gap-2 ${isLight ? 'text-slate-800' : 'text-white'}`}>
-            <Car size={20} className="text-rose-400" /> Veiculos
+            <Car size={20} className="text-teal-500" /> Veiculos
           </h1>
           <p className="text-sm text-slate-500">{veiculos.length} veiculo{veiculos.length !== 1 ? 's' : ''} cadastrado{veiculos.length !== 1 ? 's' : ''}</p>
         </div>
         <button
           onClick={() => setModal({})}
-          className="flex items-center gap-2 px-4 py-2 rounded-xl bg-rose-600 hover:bg-rose-500 text-sm text-white font-semibold transition-colors"
+          className="flex items-center gap-2 px-4 py-2 rounded-xl bg-gradient-to-r from-teal-500 to-teal-600 hover:from-teal-400 hover:to-teal-500 shadow-sm shadow-teal-500/20 text-sm text-white font-semibold transition-colors"
         >
           <Plus size={15} /> Novo Veiculo
         </button>
@@ -242,10 +244,10 @@ export default function Veiculos() {
         <div className="relative max-w-xs flex-1 min-w-[200px]">
           <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" />
           <input
-            className={`w-full pl-9 pr-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-rose-500/30 ${
+            className={`w-full pl-9 pr-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-teal-400/40 ${
               isLight
-                ? 'bg-slate-50 border border-slate-200 text-slate-800 placeholder:text-slate-400'
-                : 'bg-white/6 border border-white/10 text-white placeholder:text-slate-600'
+                ? 'bg-white border border-slate-200 shadow-sm text-slate-800 hover:border-slate-300 placeholder:text-slate-400'
+                : 'bg-white/6 border border-white/12 text-white hover:border-white/20 placeholder:text-slate-600'
             }`}
             placeholder="Buscar placa, marca, modelo..."
             value={busca}
@@ -253,12 +255,12 @@ export default function Veiculos() {
           />
         </div>
         <div>
-          <label className="text-[10px] text-slate-500 block mb-1">Status</label>
+          <label className={`block text-xs font-medium mb-1 ${isLight ? 'text-slate-600' : 'text-slate-300'}`}>Status</label>
           <select
             value={statusFiltro}
             onChange={e => setStatusFiltro(e.target.value as StatusVeiculo | '')}
-            className={`px-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-rose-500/30 ${
-              isLight ? 'bg-slate-50 border border-slate-200 text-slate-800' : 'bg-white/6 border border-white/10 text-white [&>option]:bg-slate-900'
+            className={`px-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-teal-400/40 ${
+              isLight ? 'bg-white border border-slate-200 shadow-sm text-slate-800 hover:border-slate-300' : 'bg-white/6 border border-white/12 text-white hover:border-white/20 [&>option]:bg-slate-900'
             }`}
           >
             <option value="">Todos</option>
@@ -266,12 +268,12 @@ export default function Veiculos() {
           </select>
         </div>
         <div>
-          <label className="text-[10px] text-slate-500 block mb-1">Categoria</label>
+          <label className={`block text-xs font-medium mb-1 ${isLight ? 'text-slate-600' : 'text-slate-300'}`}>Categoria</label>
           <select
             value={catFiltro}
             onChange={e => setCatFiltro(e.target.value as CategoriaVeiculo | '')}
-            className={`px-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-rose-500/30 ${
-              isLight ? 'bg-slate-50 border border-slate-200 text-slate-800' : 'bg-white/6 border border-white/10 text-white [&>option]:bg-slate-900'
+            className={`px-3 py-2 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-teal-400/40 ${
+              isLight ? 'bg-white border border-slate-200 shadow-sm text-slate-800 hover:border-slate-300' : 'bg-white/6 border border-white/12 text-white hover:border-white/20 [&>option]:bg-slate-900'
             }`}
           >
             <option value="">Todas</option>
@@ -344,7 +346,7 @@ export default function Veiculos() {
                 {/* Edit */}
                 <button
                   onClick={() => setModal(v)}
-                  className="text-slate-500 hover:text-rose-400 transition-colors"
+                  className="text-slate-500 hover:text-teal-400 transition-colors"
                 >
                   <Edit2 size={14} />
                 </button>


### PR DESCRIPTION
## Summary
- Fix critical Tailwind dynamic class bug in FrotasHome (`border-l-${accent}-500` → static map)
- Replace rose color scheme with teal across all 5 Frotas pages (FrotasHome, Veiculos, Checklists, Abastecimentos, Telemetria)
- Upgrade label contrast (`text-[11px] text-slate-400` → `text-xs font-medium` with theme-aware colors)
- Standardize inputs with `shadow-sm`, stronger borders, and teal focus rings
- Convert buttons to gradient `from-teal-500 to-teal-600` with shadow

## Test plan
- [x] Vite build passes clean
- [x] Only semantic `rose` remaining (Telemetria `fora_area` alert + FrotasHome ACCENT_BORDER map entry)
- [x] Visual verification of all 5 pages via preview screenshots
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)