### PR TITLE
fix(cadastros): fix supplier data not loading after file upload (#47)

### DIFF
--- a/frontend/src/hooks/useCadastros.ts
+++ b/frontend/src/hooks/useCadastros.ts
@@ -280,7 +280,7 @@ export function useAiCadastroParse() {
       base64?: string
       filename?: string
     }): Promise<AiCadastroResult> => {
-      const n8nUrl = import.meta.env.VITE_N8N_WEBHOOK_URL || ''
+      const n8nUrl = import.meta.env.VITE_N8N_WEBHOOK_URL || 'https://teg-agents-n8n.nmmcas.easypanel.host/webhook'
 
       if (vars.input_type === 'cnpj') {
         const clean = vars.content.replace(/\D/g, '')


### PR DESCRIPTION
## Summary
- Fixed missing n8n webhook fallback URL in `useAiCadastroParse` hook (`useCadastros.ts`)
- When `VITE_N8N_WEBHOOK_URL` env var was unset, the URL defaulted to empty string, skipping the AI parsing webhook entirely
- Supplier data now correctly loads after document upload

## Issues
Closes #47

## Test plan
- [ ] Upload a supplier document (CNPJ card, contract) in Cadastros > Fornecedores
- [ ] Verify parsed data fills the form fields automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)