### PR TITLE
fix(financeiro): payment details, supplier bank info, conciliacao filters, resumo layout (#35-37 #43)

### DIFF
--- a/frontend/src/hooks/useAprovacoes.ts
+++ b/frontend/src/hooks/useAprovacoes.ts
@@ -120,7 +120,7 @@ export function useAprovacoesPendentes(tipo?: TipoAprovacao) {
       if (finIds.length > 0) {
         const { data: finData } = await supabase
           .from('fin_contas_pagar')
-          .select('id, fornecedor_nome, valor_original, numero_documento, descricao, data_vencimento, centro_custo')
+          .select('id, fornecedor_nome, valor_original, valor_pago, numero_documento, descricao, data_vencimento, data_emissao, centro_custo, classe_financeira, natureza, forma_pagamento, status')
           .in('id', finIds)
         for (const f of finData ?? []) {
           finMap.set(f.id, f)
@@ -195,6 +195,23 @@ export function useAprovacoesPendentes(tipo?: TipoAprovacao) {
               alcada_nivel: a.nivel,
               created_at: a.created_at,
             }
+            // Issue #35: Attach enriched payment details for AprovAi card
+            if (fin) {
+              ;(a as Record<string, unknown>)._pagamento_detalhes = {
+                fornecedor_nome: (fin.fornecedor_nome as string) ?? '',
+                valor_original: (fin.valor_original as number) ?? 0,
+                valor_pago: (fin.valor_pago as number) ?? 0,
+                numero_documento: (fin.numero_documento as string) ?? '',
+                descricao: (fin.descricao as string) ?? '',
+                data_vencimento: (fin.data_vencimento as string) ?? '',
+                data_emissao: (fin.data_emissao as string) ?? '',
+                centro_custo: (fin.centro_custo as string) ?? '',
+                classe_financeira: (fin.classe_financeira as string) ?? '',
+                natureza: (fin.natureza as string) ?? '',
+                forma_pagamento: (fin.forma_pagamento as string) ?? '',
+                status_cp: (fin.status as string) ?? '',
+              }
+            }
           } else {
             requisicao = {
               id: a.entidade_id,
@@ -212,6 +229,8 @@ export function useAprovacoesPendentes(tipo?: TipoAprovacao) {
 
           const minutaResumo = (a as Record<string, unknown>)._minuta_resumo as AprovacaoPendente['minuta_resumo']
           delete (a as Record<string, unknown>)._minuta_resumo
+          const pagamentoDetalhes = (a as Record<string, unknown>)._pagamento_detalhes as AprovacaoPendente['pagamento_detalhes']
+          delete (a as Record<string, unknown>)._pagamento_detalhes
 
           return {
             ...a,
@@ -221,6 +240,7 @@ export function useAprovacoesPendentes(tipo?: TipoAprovacao) {
             requisicao,
             cotacao_resumo: cotMap.get(a.entidade_id) ?? undefined,
             minuta_resumo: minutaResumo ?? undefined,
+            pagamento_detalhes: pagamentoDetalhes ?? undefined,
           } as unknown as AprovacaoPendente
         })
         .filter((a): a is AprovacaoPendente => a !== null)

--- a/frontend/src/hooks/useFinanceiro.ts
+++ b/frontend/src/hooks/useFinanceiro.ts
@@ -85,6 +85,25 @@ export function useFornecedores() {
   })
 }
 
+// ── Fornecedor por ID (Issue #36: dados bancarios/PIX) ──────────────────────
+export function useFornecedorById(fornecedorId?: string | null) {
+  return useQuery<Fornecedor | null>({
+    queryKey: ['fornecedor', fornecedorId],
+    queryFn: async () => {
+      if (!fornecedorId) return null
+      const { data, error } = await supabase
+        .from('cmp_fornecedores')
+        .select('*')
+        .eq('id', fornecedorId)
+        .single()
+      if (error) return null
+      return data as Fornecedor
+    },
+    enabled: !!fornecedorId,
+    staleTime: 300_000,
+  })
+}
+
 // ── Aprovar Pagamento (AP): aguardando_aprovacao → aprovado_pgto ──────────
 // Autorização de Pagamento: o financeiro aprova a CP para pagamento efetivo.
 

--- a/frontend/src/pages/AprovAi.tsx
+++ b/frontend/src/pages/AprovAi.tsx
@@ -6,7 +6,7 @@ import {
   MessageSquare, ExternalLink, ArrowLeft,
   FileSearch, Banknote, FileSignature, ShoppingCart,
   History, ListChecks, Timer, TrendingUp, Filter,
-  Calendar, FileText, Download,
+  Calendar, FileText, Download, Eye, HelpCircle,
 } from 'lucide-react'
 import { useAuth } from '../contexts/AuthContext'
 import {
@@ -435,6 +435,8 @@ function GenericPendingCard({ aprovacao, aprovadorNome, aprovadorEmail }: {
         {/* ── Resumo Executivo para Minuta Contratual ── */}
         {aprovacao.tipo_aprovacao === 'minuta_contratual' && aprovacao.minuta_resumo ? (
           <MinutaExecutiveSummary resumo={aprovacao.minuta_resumo} />
+        ) : aprovacao.tipo_aprovacao === 'autorizacao_pagamento' && aprovacao.pagamento_detalhes ? (
+          <PagamentoDetalhesCard detalhes={aprovacao.pagamento_detalhes} />
         ) : aprovacao.tipo_aprovacao === 'autorizacao_pagamento' && aprovacao.requisicao ? (
           <div className="space-y-2">
             <div className="bg-slate-50 rounded-xl p-3 space-y-1.5">
@@ -537,6 +539,113 @@ function GenericPendingCard({ aprovacao, aprovadorNome, aprovadorEmail }: {
   )
 }
 
+// ── Issue #35: Pagamento Detalhes Card ────────────────────────────────────────
+
+function PagamentoDetalhesCard({ detalhes }: {
+  detalhes: NonNullable<AprovacaoPendente['pagamento_detalhes']>
+}) {
+  const [showEntender, setShowEntender] = useState(false)
+  const fmtDate = (d: string) => d ? new Date(d + 'T00:00:00').toLocaleDateString('pt-BR') : '—'
+  const isVencida = detalhes.data_vencimento && new Date(detalhes.data_vencimento) < new Date()
+
+  return (
+    <div className="space-y-2.5">
+      {/* Valor destaque */}
+      <div className={`rounded-xl p-3 flex justify-between items-center ${isVencida ? 'bg-red-50 border border-red-200' : 'bg-amber-50 border border-amber-200'}`}>
+        <div>
+          <span className={`text-xs font-medium ${isVencida ? 'text-red-700' : 'text-amber-700'}`}>
+            Valor a Pagar
+          </span>
+          {isVencida && (
+            <span className="ml-2 text-[10px] font-bold text-red-600 bg-red-100 px-1.5 py-0.5 rounded-full">VENCIDA</span>
+          )}
+        </div>
+        <span className={`text-lg font-extrabold ${isVencida ? 'text-red-700' : 'text-amber-700'}`}>
+          {fmt(detalhes.valor_original)}
+        </span>
+      </div>
+
+      {/* Info grid */}
+      <div className="bg-slate-50 rounded-xl p-3 space-y-1.5">
+        <div className="flex items-center gap-2 mb-1">
+          <Banknote size={13} className="text-teal-500" />
+          <span className="text-[11px] font-bold text-teal-600 uppercase tracking-wider">Detalhes do Pagamento</span>
+        </div>
+        <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs">
+          <div>
+            <span className="text-slate-400">Fornecedor</span>
+            <p className="font-semibold text-slate-800">{detalhes.fornecedor_nome || '—'}</p>
+          </div>
+          <div>
+            <span className="text-slate-400">Documento</span>
+            <p className="font-medium text-slate-700">{detalhes.numero_documento || '—'}</p>
+          </div>
+          <div className="col-span-2">
+            <span className="text-slate-400">Descricao</span>
+            <p className="font-medium text-slate-700 leading-snug">{detalhes.descricao || '—'}</p>
+          </div>
+          <div>
+            <span className="text-slate-400">Vencimento</span>
+            <p className={`font-medium ${isVencida ? 'text-red-600' : 'text-slate-700'}`}>{fmtDate(detalhes.data_vencimento)}</p>
+          </div>
+          <div>
+            <span className="text-slate-400">Emissao</span>
+            <p className="font-medium text-slate-700">{fmtDate(detalhes.data_emissao)}</p>
+          </div>
+          {detalhes.centro_custo && (
+            <div>
+              <span className="text-slate-400">Centro de Custo</span>
+              <p className="font-medium text-slate-700">{detalhes.centro_custo}</p>
+            </div>
+          )}
+          {detalhes.classe_financeira && (
+            <div>
+              <span className="text-slate-400">Classe Financeira</span>
+              <p className="font-medium text-slate-700">{detalhes.classe_financeira}</p>
+            </div>
+          )}
+          {detalhes.natureza && (
+            <div>
+              <span className="text-slate-400">Natureza</span>
+              <p className="font-medium text-slate-700 capitalize">{detalhes.natureza.replace(/_/g, ' ')}</p>
+            </div>
+          )}
+          {detalhes.forma_pagamento && (
+            <div>
+              <span className="text-slate-400">Forma Pagamento</span>
+              <p className="font-medium text-slate-700 capitalize">{detalhes.forma_pagamento.replace(/_/g, ' ')}</p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Entender esta autorizacao */}
+      <button
+        type="button"
+        onClick={() => setShowEntender(!showEntender)}
+        className="flex items-center gap-1.5 text-[11px] text-indigo-500 hover:text-indigo-700 font-semibold transition-colors"
+      >
+        <HelpCircle size={12} />
+        {showEntender ? 'Ocultar explicacao' : 'Entender esta autorizacao'}
+      </button>
+      {showEntender && (
+        <div className="bg-indigo-50/60 border border-indigo-100 rounded-xl p-3 text-xs text-indigo-800 leading-relaxed">
+          <p>
+            Esta e uma <strong>Autorizacao de Pagamento</strong> para o fornecedor <strong>{detalhes.fornecedor_nome}</strong> no
+            valor de <strong>{fmt(detalhes.valor_original)}</strong>
+            {detalhes.data_vencimento && <>, com vencimento em <strong>{fmtDate(detalhes.data_vencimento)}</strong></>}.
+            {detalhes.centro_custo && <> O gasto sera alocado no centro de custo <strong>{detalhes.centro_custo}</strong>.</>}
+            {isVencida && <> <span className="text-red-600 font-bold">Atencao: esta conta ja esta vencida.</span></>}
+          </p>
+          <p className="mt-1.5">
+            Ao aprovar, o financeiro podera efetuar o pagamento. Ao rejeitar, a CP voltara para revisao.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ── Minuta Executive Summary (inline in GenericPendingCard) ───────────────────
 
 function MinutaExecutiveSummary({ resumo }: {
@@ -580,12 +689,12 @@ function MinutaExecutiveSummary({ resumo }: {
         </div>
       </div>
 
-      {/* AI Analysis summary */}
+      {/* Issue #43: Executive summary as structured single text box */}
       {resumo.ai_resumo && (
         <div className="bg-violet-50/60 rounded-xl p-3">
-          <div className="flex items-center gap-2 mb-1.5">
+          <div className="flex items-center gap-2 mb-2">
             <Sparkles size={13} className="text-violet-500" />
-            <span className="text-[11px] font-bold text-violet-600 uppercase tracking-wider">Analise IA</span>
+            <span className="text-[11px] font-bold text-violet-600 uppercase tracking-wider">Parecer / Resumo Executivo</span>
             {typeof resumo.ai_score === 'number' && (
               <span className={`ml-auto text-[11px] font-extrabold px-2 py-0.5 rounded-full ${
                 resumo.ai_score >= 80 ? 'bg-emerald-100 text-emerald-700' :
@@ -596,7 +705,21 @@ function MinutaExecutiveSummary({ resumo }: {
               </span>
             )}
           </div>
-          <p className="text-xs text-slate-600 leading-relaxed line-clamp-4">{resumo.ai_resumo}</p>
+          <div className="bg-white/80 border border-violet-100 rounded-lg p-3 space-y-2.5 max-h-64 overflow-y-auto text-xs text-slate-700 leading-relaxed">
+            {resumo.ai_resumo.split('\n\n').map((section, idx) => {
+              const lines = section.split('\n')
+              const isHeader = lines[0] === lines[0].toUpperCase() && lines.length > 1
+              if (isHeader) {
+                return (
+                  <div key={idx}>
+                    <p className="text-[10px] font-bold text-violet-500 uppercase tracking-wider mb-0.5">{lines[0]}</p>
+                    <p className="whitespace-pre-line">{lines.slice(1).join('\n')}</p>
+                  </div>
+                )
+              }
+              return <p key={idx} className="whitespace-pre-line">{section}</p>
+            })}
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/financeiro/Conciliacao.tsx
+++ b/frontend/src/pages/financeiro/Conciliacao.tsx
@@ -136,6 +136,8 @@ export default function Conciliacao() {
   const [dataFim, setDataFim] = useState('')
   const [filtroSemCC, setFiltroSemCC] = useState(false)
   const [filtroSemClasse, setFiltroSemClasse] = useState(false)
+  const [filtroCC, setFiltroCC] = useState('')
+  const [filtroClasse, setFiltroClasse] = useState('')
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [showClassModal, setShowClassModal] = useState(false)
   const [toast, setToast] = useState<{ type: 'success' | 'error'; msg: string } | null>(null)
@@ -214,9 +216,11 @@ export default function Conciliacao() {
       if (dataFim && r.vencimento > dataFim) return false
       if (filtroSemCC && r.centroCusto) return false
       if (filtroSemClasse && r.classeFinanceira) return false
+      if (filtroCC && r.centroCusto !== filtroCC) return false
+      if (filtroClasse && r.classeFinanceira !== filtroClasse) return false
       return true
     })
-  }, [rows, busca, dataInicio, dataFim, filtroSemCC, filtroSemClasse])
+  }, [rows, busca, dataInicio, dataFim, filtroSemCC, filtroSemClasse, filtroCC, filtroClasse])
 
   // Selection helpers
   const allSelected = filtered.length > 0 && filtered.every(r => selected.has(r.id))
@@ -249,6 +253,8 @@ export default function Conciliacao() {
     setDataFim('')
     setFiltroSemCC(false)
     setFiltroSemClasse(false)
+    setFiltroCC('')
+    setFiltroClasse('')
   }
 
   const showToast = (type: 'success' | 'error', msg: string) => {
@@ -474,8 +480,35 @@ export default function Conciliacao() {
               />
             </div>
           </div>
+          {/* Issue #37: CC and Classe dropdowns */}
+          <div className="flex gap-2">
+            <select
+              value={filtroCC}
+              onChange={e => { setFiltroCC(e.target.value); if (e.target.value) setFiltroSemCC(false) }}
+              className={`px-3 py-2.5 rounded-xl border text-xs
+                focus:outline-none focus:ring-2 focus:ring-emerald-500/30 focus:border-emerald-400
+                ${isDark ? 'bg-white/[0.03] border-white/[0.06] text-slate-300' : 'border-slate-200 bg-slate-50 text-slate-600'}`}
+            >
+              <option value="">Centro de Custo</option>
+              {ccSuggestions.map(cc => (
+                <option key={cc} value={cc}>{cc}</option>
+              ))}
+            </select>
+            <select
+              value={filtroClasse}
+              onChange={e => { setFiltroClasse(e.target.value); if (e.target.value) setFiltroSemClasse(false) }}
+              className={`px-3 py-2.5 rounded-xl border text-xs
+                focus:outline-none focus:ring-2 focus:ring-emerald-500/30 focus:border-emerald-400
+                ${isDark ? 'bg-white/[0.03] border-white/[0.06] text-slate-300' : 'border-slate-200 bg-slate-50 text-slate-600'}`}
+            >
+              <option value="">Classe Financeira</option>
+              {classeSuggestions.map(cl => (
+                <option key={cl} value={cl}>{cl}</option>
+              ))}
+            </select>
+          </div>
         </div>
-        {(busca || dataInicio || dataFim || filtroSemCC || filtroSemClasse) && (
+        {(busca || dataInicio || dataFim || filtroSemCC || filtroSemClasse || filtroCC || filtroClasse) && (
           <div className="flex items-center gap-2 flex-wrap">
             <span className="text-[10px] text-slate-400">Filtros ativos:</span>
             {busca && (
@@ -513,8 +546,22 @@ export default function Conciliacao() {
                 <button onClick={() => setFiltroSemClasse(false)}><X size={9} /></button>
               </span>
             )}
+            {filtroCC && (
+              <span className="inline-flex items-center gap-1 bg-teal-100 text-teal-700 text-[10px] font-semibold
+                rounded-full px-2 py-0.5">
+                CC: {filtroCC}
+                <button onClick={() => setFiltroCC('')}><X size={9} /></button>
+              </span>
+            )}
+            {filtroClasse && (
+              <span className="inline-flex items-center gap-1 bg-purple-100 text-purple-700 text-[10px] font-semibold
+                rounded-full px-2 py-0.5">
+                Classe: {filtroClasse}
+                <button onClick={() => setFiltroClasse('')}><X size={9} /></button>
+              </span>
+            )}
             <button
-              onClick={() => { setBusca(''); setDataInicio(''); setDataFim(''); setFiltroSemCC(false); setFiltroSemClasse(false) }}
+              onClick={() => { setBusca(''); setDataInicio(''); setDataFim(''); setFiltroSemCC(false); setFiltroSemClasse(false); setFiltroCC(''); setFiltroClasse('') }}
               className="text-[10px] text-red-500 font-semibold hover:underline"
             >
               Limpar tudo

--- a/frontend/src/pages/financeiro/ContasPagar.tsx
+++ b/frontend/src/pages/financeiro/ContasPagar.tsx
@@ -7,7 +7,7 @@ import {
   ShieldCheck, Building2, Tag, Briefcase, Hash,
 } from 'lucide-react'
 import { useTheme } from '../../contexts/ThemeContext'
-import { useContasPagar, useMarcarCPPago, useAprovarPagamento } from '../../hooks/useFinanceiro'
+import { useContasPagar, useMarcarCPPago, useAprovarPagamento, useFornecedorById } from '../../hooks/useFinanceiro'
 import { useLastSync, useTriggerSync, useOmieConfig } from '../../hooks/useOmie'
 import { useAnexosPedido, useUploadAnexo, TIPO_LABEL } from '../../hooks/useAnexos'
 import { useRegistrarPagamento } from '../../hooks/usePedidos'
@@ -312,6 +312,70 @@ const FILTROS_STATUS: { label: string; value: string }[] = [
   { label: 'Conciliados',     value: 'conciliado' },
 ]
 
+// ── Issue #36: Dados bancarios/PIX do fornecedor ──────────────────────────────
+
+function FornecedorPagamentoInfo({ fornecedorId, isDark }: { fornecedorId: string; isDark: boolean }) {
+  const { data: forn, isLoading } = useFornecedorById(fornecedorId)
+
+  if (isLoading) {
+    return (
+      <div className={`rounded-xl p-3 ${isDark ? 'bg-white/[0.04]' : 'bg-blue-50/60'}`}>
+        <p className="text-[10px] text-slate-400 animate-pulse">Carregando dados bancarios...</p>
+      </div>
+    )
+  }
+
+  if (!forn) return null
+  const hasBankData = forn.banco_nome || forn.agencia || forn.conta || forn.pix_chave
+  if (!hasBankData) return null
+
+  return (
+    <div className={`rounded-xl p-3 space-y-1.5 ${isDark ? 'bg-white/[0.04]' : 'bg-blue-50/60'}`}>
+      <p className="text-[10px] font-bold text-blue-500 uppercase tracking-wider flex items-center gap-1.5">
+        <Banknote size={10} /> Dados de Pagamento do Fornecedor
+      </p>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-[11px]">
+        {forn.razao_social && (
+          <div className="col-span-2">
+            <span className="text-slate-400">Razao Social:</span>{' '}
+            <span className="font-semibold text-slate-700">{forn.razao_social}</span>
+          </div>
+        )}
+        {forn.cnpj && (
+          <div>
+            <span className="text-slate-400">CNPJ:</span>{' '}
+            <span className="font-mono text-slate-600">{forn.cnpj}</span>
+          </div>
+        )}
+        {forn.banco_nome && (
+          <div>
+            <span className="text-slate-400">Banco:</span>{' '}
+            <span className="font-semibold text-slate-700">{forn.banco_nome}</span>
+          </div>
+        )}
+        {forn.agencia && (
+          <div>
+            <span className="text-slate-400">Agencia:</span>{' '}
+            <span className="font-mono text-slate-700">{forn.agencia}</span>
+          </div>
+        )}
+        {forn.conta && (
+          <div>
+            <span className="text-slate-400">Conta:</span>{' '}
+            <span className="font-mono text-slate-700">{forn.conta}</span>
+          </div>
+        )}
+        {forn.pix_chave && (
+          <div className="col-span-2">
+            <span className="text-slate-400">PIX ({forn.pix_tipo || 'chave'}):</span>{' '}
+            <span className="font-mono text-blue-700 font-semibold">{forn.pix_chave}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
 // ── CPCard ────────────────────────────────────────────────────────────────────
 
 function CPCard({ cp, onRegistrarPgto, onAprovarPgto, isDark }: {
@@ -516,6 +580,11 @@ function CPCard({ cp, onRegistrarPgto, onAprovarPgto, isDark }: {
                 )}
               </div>
             </div>
+          )}
+
+          {/* Issue #36: Dados bancarios/PIX do fornecedor */}
+          {cp.fornecedor_id && (
+            <FornecedorPagamentoInfo fornecedorId={cp.fornecedor_id} isDark={isDark} />
           )}
 
           {/* Anexos */}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -141,6 +141,20 @@ export interface AprovacaoPendente extends Aprovacao {
     ai_resumo: string | null
     ai_score: number | null
   }
+  pagamento_detalhes?: {
+    fornecedor_nome: string
+    valor_original: number
+    valor_pago: number
+    numero_documento: string
+    descricao: string
+    data_vencimento: string
+    data_emissao: string
+    centro_custo: string
+    classe_financeira: string
+    natureza: string
+    forma_pagamento: string
+    status_cp: string
+  }
 }
 
 export interface AprovacaoHistorico {


### PR DESCRIPTION
## Summary
- **#35**: Added `PagamentoDetalhesCard` in AprovAi with payment details grid + "Entender esta autorizacao" toggle
- **#36**: Added `FornecedorPagamentoInfo` showing supplier bank/PIX data in Contas a Pagar detail view
- **#37**: Added Centro de Custo and Classe Financeira filter dropdowns in Conciliacao screen
- **#43**: Resumo executivo now rendered as structured scrollable text box with labeled sections

## Issues
Closes #35, closes #36, closes #37, closes #43

## Files changed (6)
- `frontend/src/types/index.ts` — added `pagamento_detalhes` to AprovacaoPendente
- `frontend/src/hooks/useAprovacoes.ts` — enriched fin_contas_pagar query
- `frontend/src/hooks/useFinanceiro.ts` — added `useFornecedorById` hook
- `frontend/src/pages/AprovAi.tsx` — PagamentoDetalhesCard + MinutaExecutiveSummary
- `frontend/src/pages/financeiro/ContasPagar.tsx` — FornecedorPagamentoInfo component
- `frontend/src/pages/financeiro/Conciliacao.tsx` — CC and Classe filters

## Test plan
- [ ] Open payment approval in AprovAi and verify details grid + Entender toggle
- [ ] Open CP detail and verify supplier bank/PIX info appears
- [ ] Open Conciliacao and verify CC/Classe dropdowns are populated and filter correctly
- [ ] View resumo executivo and verify structured layout with sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)