### PR TITLE
fix(fiscal): NF requests from Logistica now visible in Emissao NF (#48)

### DIFF
--- a/frontend/src/pages/fiscal/EmissaoNF.tsx
+++ b/frontend/src/pages/fiscal/EmissaoNF.tsx
@@ -1,29 +1,5 @@
-import { FileOutput, Clock } from 'lucide-react'
-import { useTheme } from '../../contexts/ThemeContext'
+import SolicitacaoNF from './SolicitacaoNF'
 
 export default function EmissaoNF() {
-  const { isDark } = useTheme()
-
-  return (
-    <div className="flex flex-col items-center justify-center py-24 px-4">
-      <div className={`w-20 h-20 rounded-2xl flex items-center justify-center mb-6
-        ${isDark ? 'bg-amber-500/10' : 'bg-amber-50'}`}>
-        <FileOutput size={36} className={isDark ? 'text-amber-400' : 'text-amber-500'} />
-      </div>
-
-      <h2 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-slate-800'}`}>
-        Emissão de Nota Fiscal
-      </h2>
-      <p className={`text-sm mb-6 max-w-md text-center ${isDark ? 'text-slate-400' : 'text-slate-500'}`}>
-        Emissão de notas fiscais de saída e serviço.
-        Este módulo está em desenvolvimento.
-      </p>
-
-      <div className={`inline-flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-semibold
-        ${isDark ? 'bg-amber-500/10 text-amber-300 border border-amber-500/20' : 'bg-amber-50 text-amber-600 border border-amber-200'}`}>
-        <Clock size={14} />
-        Em breve
-      </div>
-    </div>
-  )
+  return <SolicitacaoNF mode="emissao" />
 }

--- a/frontend/src/pages/fiscal/SolicitacaoNF.tsx
+++ b/frontend/src/pages/fiscal/SolicitacaoNF.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback } from 'react'
 import {
-  FileInput, Clock, CheckCircle2, XCircle, Search, Filter,
+  FileInput, FileOutput, Clock, CheckCircle2, XCircle, Search, Filter,
   ArrowRight, Edit3, Send, ThumbsUp, ThumbsDown, Building2,
   Calendar, Hash, AlertTriangle, Loader2, X, FileText,
   Truck, ShoppingCart, PenLine, Eye, ChevronDown, Key,
@@ -1200,14 +1200,18 @@ function SummaryPill({
 
 // ── Main Page ───────────────────────────────────────────────────────────────
 
-export default function SolicitacaoNF() {
+export default function SolicitacaoNF({ mode = 'solicitacao' }: { mode?: 'solicitacao' | 'emissao' } = {}) {
   const { isDark } = useTheme()
   const { role } = useAuth()
   const now = new Date()
   const isGestor = role === 'admin' || role === 'gerente'
 
+  const isEmissaoMode = mode === 'emissao'
+
   // ── Filters ─────────────────────────────────────────────────────────────
-  const [statusFilter, setStatusFilter] = useState<StatusSolicitacaoNF | ''>('')
+  const [statusFilter, setStatusFilter] = useState<StatusSolicitacaoNF | ''>(
+    isEmissaoMode ? 'pendente' : ''
+  )
   const [mes, setMes] = useState(now.getMonth() + 1)
   const [ano, setAno] = useState(now.getFullYear())
   const [busca, setBusca] = useState('')
@@ -1334,11 +1338,16 @@ export default function SolicitacaoNF() {
           <h1 className={`text-xl font-extrabold flex items-center gap-2 ${
             isDark ? 'text-slate-100' : 'text-slate-800'
           }`}>
-            <FileInput size={20} className={isDark ? 'text-amber-400' : 'text-amber-500'} />
-            Solicitacao de NF
+            {isEmissaoMode
+              ? <><FileOutput size={20} className={isDark ? 'text-amber-400' : 'text-amber-500'} /> Emissao de NF</>
+              : <><FileInput size={20} className={isDark ? 'text-amber-400' : 'text-amber-500'} /> Solicitacao de NF</>
+            }
           </h1>
           <p className={`text-xs mt-0.5 ${isDark ? 'text-slate-500' : 'text-slate-400'}`}>
-            Processar solicitacoes recebidas de Logistica e Compras
+            {isEmissaoMode
+              ? 'Fila de emissao — NFs pendentes de Logistica e Compras'
+              : 'Processar solicitacoes recebidas de Logistica e Compras'
+            }
           </p>
         </div>
         <div className={`flex items-center gap-2 text-[11px] font-semibold px-3 py-1.5 rounded-xl border ${


### PR DESCRIPTION
## Summary
- Replaced EmissaoNF.tsx placeholder stub ("Em breve") with actual functionality
- Reuses SolicitacaoNF component with `mode="emissao"` prop
- Emissao mode defaults to pendente filter showing NF queue from Logistica/Compras

## Issues
Closes #48

## Files changed
- `frontend/src/pages/fiscal/EmissaoNF.tsx` — renders SolicitacaoNF in emissao mode
- `frontend/src/pages/fiscal/SolicitacaoNF.tsx` — added mode prop with emission-focused header/filter

## Test plan
- [ ] Navigate to Fiscal > Emissao NF
- [ ] Verify NF requests from Logistica appear in the queue
- [ ] Verify filter defaults to pendente status

🤖 Generated with [Claude Code](https://claude.com/claude-code)