### PR TITLE
fix(logistica): delivery text, transport obra/CC dropdowns, romaneio download (#39-41)

### DIFF
--- a/frontend/src/pages/Pedidos.tsx
+++ b/frontend/src/pages/Pedidos.tsx
@@ -942,7 +942,7 @@ function PedidoCard({
               {confirmando
                 ? <div className="w-3.5 h-3.5 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" />
                 : <CheckCircle size={14} />}
-              Confirmar Entrega (sem recebimento)
+              Confirmar Entrega Direta
             </button>
           )}
 

--- a/frontend/src/pages/logistica/Expedicao.tsx
+++ b/frontend/src/pages/logistica/Expedicao.tsx
@@ -106,6 +106,32 @@ export default function Expedicao() {
     setRomaneioModal(null)
   }
 
+  function downloadRomaneio(s: LogSolicitacao) {
+    const url = gerarRomaneioPDF({
+      numero: s.numero,
+      origem: s.origem,
+      destino: s.destino,
+      obra_nome: s.obra_nome,
+      solicitante: s.solicitante_nome,
+      motorista_nome: s.motorista_nome,
+      veiculo_placa: s.veiculo_placa,
+      peso_total_kg: s.peso_total_kg,
+      volumes_total: s.volumes_total,
+      observacoes: s.observacoes_carga,
+      itens: (s.itens ?? []).map(i => ({
+        descricao: i.descricao,
+        quantidade: i.quantidade,
+        unidade: i.unidade,
+        peso_kg: i.peso_kg,
+      })),
+    })
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `romaneio-${s.numero}.pdf`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
   // ── Solicitar NF handler ──
 
   async function handleSolicitarNF() {
@@ -656,11 +682,11 @@ function getDocStatus(s: LogSolicitacao) {
         </span>
       ),
       rightInfo: s.romaneio_url ? (
-        <a href={s.romaneio_url} target="_blank" rel="noreferrer"
+        <button
           className="text-[10px] text-teal-600 hover:text-teal-700 font-semibold flex items-center gap-1"
-          onClick={e => e.stopPropagation()}>
+          onClick={e => { e.stopPropagation(); downloadRomaneio(s) }}>
           <Download size={10} /> Download
-        </a>
+        </button>
       ) : null,
     }
   }
@@ -814,10 +840,10 @@ function ExpedicaoDetail({
               </div>
             </div>
             {solicitacao.romaneio_url && (
-              <a href={solicitacao.romaneio_url} target="_blank" rel="noreferrer"
+              <button onClick={() => downloadRomaneio(solicitacao)}
                 className="inline-flex items-center gap-1 text-[10px] text-teal-700 hover:text-teal-800 font-semibold mt-1 ml-5">
                 <Download size={9} /> Download Romaneio
-              </a>
+              </button>
             )}
           </div>
         )

--- a/frontend/src/pages/logistica/Solicitacoes.tsx
+++ b/frontend/src/pages/logistica/Solicitacoes.tsx
@@ -14,6 +14,7 @@ import { StatusBadge } from './LogisticaHome'
 import { useTheme } from '../../contexts/ThemeContext'
 import type { CriarSolicitacaoPayload, TipoTransporte, StatusSolicitacao } from '../../types/logistica'
 import { useNavigate } from 'react-router-dom'
+import { useLookupObras, useLookupCentrosCusto } from '../../hooks/useLookups'
 
 const TIPO_LABEL: Record<TipoTransporte, string> = {
   viagem:                  'Viagem',
@@ -65,6 +66,8 @@ export default function Solicitacoes() {
   const [nfForm, setNfForm] = useState({ fornecedor_cnpj: '', fornecedor_nome: '', valor_total: 0, descricao: '' })
   const [itensForm, setItensForm] = useState<{ descricao: string; quantidade: number; unidade: string; peso_kg?: number; volume_m3?: number }[]>([])
   const navigate = useNavigate()
+  const obras = useLookupObras()
+  const centrosCusto = useLookupCentrosCusto()
 
   const { data: solicitacoes = [], isLoading } = useSolicitacoes(
     statusFiltro ? { status: statusFiltro as StatusSolicitacao } : undefined
@@ -400,13 +403,23 @@ export default function Solicitacoes() {
               <div className="grid grid-cols-2 gap-3">
                 <div>
                   <label className={`block text-xs font-bold mb-1 ${isDark ? 'text-slate-300' : 'text-slate-600'}`}>Obra / Projeto</label>
-                  <input value={form.obra_nome ?? ''} onChange={e => set('obra_nome', e.target.value)}
-                    className="input-base" placeholder="SE Frutal..." />
+                  <select value={form.obra_nome ?? ''} onChange={e => set('obra_nome', e.target.value)}
+                    className="input-base">
+                    <option value="">Selecione...</option>
+                    {obras.map(o => (
+                      <option key={o.id} value={o.nome}>{o.codigo} - {o.nome}</option>
+                    ))}
+                  </select>
                 </div>
                 <div>
                   <label className={`block text-xs font-bold mb-1 ${isDark ? 'text-slate-300' : 'text-slate-600'}`}>Centro de Custo</label>
-                  <input value={form.centro_custo ?? ''} onChange={e => set('centro_custo', e.target.value)}
-                    className="input-base" placeholder="CC-001" />
+                  <select value={form.centro_custo ?? ''} onChange={e => set('centro_custo', e.target.value)}
+                    className="input-base">
+                    <option value="">Selecione...</option>
+                    {centrosCusto.map(cc => (
+                      <option key={cc.id} value={cc.codigo}>{cc.codigo} - {cc.descricao}</option>
+                    ))}
+                  </select>
                 </div>
               </div>
               <div className="grid grid-cols-2 gap-3">


### PR DESCRIPTION
## Summary
- **#39**: Changed confusing "Confirmar Entrega (sem recebimento)" to "Confirmar Entrega Direta"
- **#40**: Transport request now loads Obras and Centro de Custo from Supabase via useLookup hooks with proper select dropdowns
- **#41**: Romaneio download regenerates PDF on-demand instead of using ephemeral blob URLs

## Issues
Closes #39, closes #40, closes #41

## Files changed
- `frontend/src/pages/Pedidos.tsx` — button text (#39)
- `frontend/src/pages/logistica/Solicitacoes.tsx` — Obra/CC dropdowns (#40)
- `frontend/src/pages/logistica/Expedicao.tsx` — romaneio regeneration (#41)

## Test plan
- [ ] Check delivery button text says "Confirmar Entrega Direta"
- [ ] Open Logistica > Solicitacoes and verify Obra/CC dropdowns load data
- [ ] Open Logistica > Expedicao and verify romaneio download works

🤖 Generated with [Claude Code](https://claude.com/claude-code)