### PR TITLE
fix(contratos): selects para centro de custo e classe financeira na solicitação

### DIFF
--- a/frontend/src/pages/contratos/NovaSolicitacao.tsx
+++ b/frontend/src/pages/contratos/NovaSolicitacao.tsx
@@ -8,6 +8,7 @@ import {
 } from 'lucide-react'
 import { useAuth } from '../../contexts/AuthContext'
 import { useObras } from '../../hooks/useFinanceiro'
+import { useLookupCentrosCusto, useLookupClassesFinanceiras } from '../../hooks/useLookups'
 import { useCriarSolicitacao } from '../../hooks/useSolicitacoes'
 import { api } from '../../services/api'
 import type {
@@ -140,6 +141,8 @@ export default function NovaSolicitacao() {
   const nav = useNavigate()
   const { perfil } = useAuth()
   const { data: obras = [] } = useObras()
+  const centrosCusto = useLookupCentrosCusto()
+  const classesFinanceiras = useLookupClassesFinanceiras()
   const criarSolicitacao = useCriarSolicitacao()
 
   const [step, setStep] = useState(1)
@@ -815,21 +818,29 @@ export default function NovaSolicitacao() {
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
             <div>
               <label className={labelClass}>Centro de Custo</label>
-              <input
+              <select
                 value={centroCusto}
                 onChange={e => setCentroCusto(e.target.value)}
-                placeholder="Ex: ADM, OBRA-123"
                 className={inputClass}
-              />
+              >
+                <option value="">Selecione o centro de custo</option>
+                {centrosCusto.map(cc => (
+                  <option key={cc.id} value={cc.descricao}>{cc.codigo ? `${cc.codigo} - ` : ''}{cc.descricao}</option>
+                ))}
+              </select>
             </div>
             <div>
               <label className={labelClass}>Classe Financeira</label>
-              <input
+              <select
                 value={classeFinanceira}
                 onChange={e => setClasseFinanceira(e.target.value)}
-                placeholder="Ex: Servicos, Materiais"
                 className={inputClass}
-              />
+              >
+                <option value="">Selecione a classe financeira</option>
+                {classesFinanceiras.map(cf => (
+                  <option key={cf.id} value={cf.descricao}>{cf.codigo ? `${cf.codigo} - ` : ''}{cf.descricao}</option>
+                ))}
+              </select>
             </div>
             <div>
               <label className={labelClass}>Indice de Reajuste</label>


### PR DESCRIPTION
## Summary
- Troca inputs de texto por `<select>` dropdowns para Centro de Custo e Classe Financeira no Step 3 (Vigência e Classificação) da solicitação de contrato
- Usa `useLookupCentrosCusto` e `useLookupClassesFinanceiras` para popular as opções do banco

## Test plan
- [ ] Abrir Nova Solicitação de Contrato → Step 3
- [ ] Verificar que Centro de Custo mostra dropdown com opções do banco
- [ ] Verificar que Classe Financeira mostra dropdown com opções do banco
- [ ] Submeter solicitação e confirmar valores salvos corretamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)