### PR TITLE
fix(certisign): add 'erro' status to con_assinaturas (#76)

### DIFF
--- a/frontend/src/types/contratos.ts
+++ b/frontend/src/types/contratos.ts
@@ -512,7 +512,7 @@ export interface NovaSolicitacaoPayload {
 
 // ── Certisign Assinaturas ───────────────────────────────────────────
 
-export type StatusAssinaturaType = 'pendente' | 'enviado' | 'parcialmente_assinado' | 'assinado' | 'recusado' | 'expirado' | 'cancelado'
+export type StatusAssinaturaType = 'pendente' | 'enviado' | 'parcialmente_assinado' | 'assinado' | 'recusado' | 'expirado' | 'cancelado' | 'erro'
 export type ProvedorAssinatura = 'certisign' | 'manual'
 export type TipoAssinatura = 'eletronica' | 'digital_icp'
 

--- a/supabase/045_con_assinaturas.sql
+++ b/supabase/045_con_assinaturas.sql
@@ -14,7 +14,7 @@ CREATE TABLE con_assinaturas (
   envelope_id             TEXT,
   status                  TEXT NOT NULL DEFAULT 'pendente'
                           CHECK (status IN ('pendente','enviado','parcialmente_assinado',
-                                            'assinado','recusado','expirado','cancelado')),
+                                            'assinado','recusado','expirado','cancelado','erro')),
   signatarios             JSONB NOT NULL DEFAULT '[]',
   enviado_em              TIMESTAMPTZ,
   concluido_em            TIMESTAMPTZ,


### PR DESCRIPTION
## Summary
- Added `'erro'` to the `status` CHECK constraint in `con_assinaturas` migration
- Added `'erro'` to `StatusAssinaturaType` in `contratos.ts`
- Fixes: n8n Certisign workflow error path can now insert records with status `'erro'` when the API call fails

## Context
During end-to-end testing of the Certisign signature flow, the n8n workflow's error path failed to insert into `con_assinaturas` because the `'erro'` status wasn't in the CHECK constraint. The DB constraint was already updated live via ALTER TABLE; this PR syncs the migration file and TypeScript types.

## Test plan
- [x] Tested end-to-end in browser: CertisignModal → n8n webhook → error path → con_assinaturas record created with status 'erro'
- [x] Solicitação correctly advances after signature submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)