### PR TITLE
fix(financeiro): alinhar cabecalho da tabela de lotes

### DIFF
--- a/frontend/src/pages/financeiro/CPPipeline.tsx
+++ b/frontend/src/pages/financeiro/CPPipeline.tsx
@@ -3625,8 +3625,8 @@ export default function CPPipeline() {
                 <span>Resumo</span>
                 <span>Qtd</span>
                 <span>Aprov.</span>
-                <span className="text-right">Valor</span>
-                <span className="text-right">Ações</span>
+                <span className="pr-4 text-right">Valor</span>
+                <span className="pl-5 text-right">Ações</span>
               </div>
               {activeLotes.map(summary => {
                 const actions = buildLoteActions(summary)


### PR DESCRIPTION
## Resumo
- reposiciona os titulos Valor e Acoes no header da tabela de lotes
- alinha o cabecalho com o novo espacamento da coluna de valor e da rail de acoes