### PR TITLE
fix(financeiro): centralizar titulo de acoes em lotes

### DIFF
--- a/frontend/src/pages/financeiro/CPPipeline.tsx
+++ b/frontend/src/pages/financeiro/CPPipeline.tsx
@@ -3626,7 +3626,7 @@ export default function CPPipeline() {
                 <span>Qtd</span>
                 <span>Aprov.</span>
                 <span className="text-left">Valor</span>
-                <span className="pl-5 pr-4 text-left">Ações</span>
+                <span className="flex justify-center pl-5 pr-4">Ações</span>
               </div>
               {activeLotes.map(summary => {
                 const actions = buildLoteActions(summary)


### PR DESCRIPTION
Centraliza o titulo Acoes no mesmo eixo visual da rail de botoes da tabela de lotes.