### PR TITLE
fix(compras): corrige 'ExternalLink is not defined' ao anexar referencia de cotacao

### DIFF
--- a/frontend/src/pages/NovaRequisicao.tsx
+++ b/frontend/src/pages/NovaRequisicao.tsx
@@ -4,7 +4,7 @@ import {
   Sparkles, Send, PlusCircle, Trash2, ChevronLeft, ChevronRight,
   AlertCircle, Check, Layers, FileText, Search, Upload, FileUp,
   ChevronDown, X, FileImage, Eye, Pencil, CheckCircle2, Loader2,
-  Package, MapPin, Zap, Save,
+  Package, MapPin, Zap, Save, ExternalLink, Download,
 } from 'lucide-react'
 import { useCriarRequisicao, useAtualizarRequisicao, useRequisicao, useReenviarAposDevolucao } from '../hooks/useRequisicoes'
 import { useAiParse, readFileForAi, isBinaryFile, isImageFile } from '../hooks/useAiParse'


### PR DESCRIPTION
## Resumo

Corrige o `ReferenceError: ExternalLink is not defined` que estoura a ErrorBoundary
em **Compras → Nova Solicitação** ao anexar um arquivo de **Referência de cotação**.

## Causa

Em `frontend/src/pages/NovaRequisicao.tsx` (etapa 2), os ícones `<ExternalLink>`
(linha 715 — botão "Visualizar") e `<Download>` (linha 723 — botão "Download")
eram renderizados no preview do arquivo anexado, mas nenhum dos dois estava
importado de `lucide-react`. Assim que o arquivo era selecionado e o React
re-renderizava a área de preview, lançava `ReferenceError`.

## Correção

Adicionados `ExternalLink` e `Download` ao import de `lucide-react`:

```diff
-  Package, MapPin, Zap, Save,
+  Package, MapPin, Zap, Save, ExternalLink, Download,
 } from 'lucide-react'
```

## Test plan

- [ ] Ir em **Compras → Nova Solicitação**
- [ ] Selecionar uma categoria e avançar para a etapa 2
- [ ] Clicar na área **"Referência de cotação"** e anexar um PDF/XLSX/JPG
- [ ] Verificar que o card do arquivo aparece com os botões **Visualizar** e **Download** funcionando, sem ErrorBoundary
- [ ] Clicar em **Visualizar** — deve abrir o arquivo em nova aba
- [ ] Clicar em **Download** — deve baixar o arquivo com o nome original

https://claude.ai/code/session_01By4HbzgWzD4dB3cv2SqqpY