### PR TITLE
fix(requisicoes): importa ExternalLink e Download em NovaRequisicao

### DIFF
--- a/frontend/src/pages/NovaRequisicao.tsx
+++ b/frontend/src/pages/NovaRequisicao.tsx
@@ -4,7 +4,7 @@ import {
   Sparkles, Send, PlusCircle, Trash2, ChevronLeft, ChevronRight,
   AlertCircle, Check, Layers, FileText, Search, Upload, FileUp,
   ChevronDown, X, FileImage, Eye, Pencil, CheckCircle2, Loader2,
-  Package, MapPin, Zap, Save,
+  Package, MapPin, Zap, Save, ExternalLink, Download,
 } from 'lucide-react'
 import { useCriarRequisicao, useAtualizarRequisicao, useRequisicao, useReenviarAposDevolucao } from '../hooks/useRequisicoes'
 import { useAiParse, readFileForAi, isBinaryFile, isImageFile } from '../hooks/useAiParse'


### PR DESCRIPTION
## Resumo
- `ExternalLink` e `Download` eram renderizados no JSX de `NovaRequisicao.tsx` (linhas 715 e 723) mas não estavam no import de `lucide-react`, causando `ReferenceError: ExternalLink is not defined` em runtime — o que disparava o error boundary ("Algo deu errado") na rota `/nova` em produção, especialmente ao anexar um arquivo de referência.
- Correção: adicionados `ExternalLink` e `Download` ao import de `lucide-react` em `frontend/src/pages/NovaRequisicao.tsx`.

## Validacao local
- `npx tsc --noEmit` — sem erros novos
- `npm run build` — `built in 15.58s`, sem falhas
- `require('lucide-react').ExternalLink` / `.Download` confirmam existência dos exports

## Test plan
- [ ] Abrir `/nova` logado
- [ ] Anexar um arquivo no card de upload de referência
- [ ] Verificar que os botões **Visualizar** e **Download** renderizam (sem tela de erro)
- [ ] Confirmar que o fluxo de criação da requisição continua funcionando

https://claude.ai/code/session_01Eo3TVWPiCWHwg2JF5euLGJ