### PR TITLE
feat(requisicoes): desabilita leitura automatica da IA no anexo de referencia

### DIFF
--- a/frontend/src/pages/NovaRequisicao.tsx
+++ b/frontend/src/pages/NovaRequisicao.tsx
@@ -654,7 +654,6 @@ export default function NovaRequisicao() {
               const file = event.target.files?.[0]
               if (file) {
                 setReferenciaFile(file)
-                handleAiParse(file)
               }
             }}
           />


### PR DESCRIPTION
## Resumo
- Remove a chamada automática de `handleAiParse(file)` no `onChange` do input de arquivo de referência em `NovaRequisicao.tsx`.
- O anexo passa a apenas ser armazenado no state (`setReferenciaFile`) — sem extração automática de itens via IA.
- Toda a infraestrutura de IA (`handleAiParse`, `useAiParse`, estados de preview) permanece intacta, apenas não é mais disparada automaticamente no upload.

## Validação local
- `npm run build` — `built in 19.57s`, sem falhas
- `tsc --noEmit` — sem erros novos em `NovaRequisicao.tsx` (apenas o pré-existente em `useRequisicoes.ts` não-relacionado)

## Test plan
- [ ] Abrir `/nova` logado
- [ ] Anexar um arquivo no card "Referência de cotação"
- [ ] Verificar que o arquivo sobe e mostra nome/tamanho + botões Visualizar/Download, **sem** spinner "Lendo arquivo..." ou "Extraindo itens com IA..."
- [ ] Preencher requisição manualmente e enviar — fluxo normal

https://claude.ai/code/session_01Eo3TVWPiCWHwg2JF5euLGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eo3TVWPiCWHwg2JF5euLGJ)_