### PR TITLE
fix(obras): auxiliar de limpeza vira Apoio (some do Time)

### DIFF
--- a/frontend/src/hooks/useObras.ts
+++ b/frontend/src/hooks/useObras.ts
@@ -25,6 +25,7 @@ export function papelSugerido(cargo?: string | null, departamento?: string | nul
   if (/SUPERVISOR/.test(c)) return 'supervisor'
   if (/ENCARREGAD|MESTRE|TOPOGRAF/.test(c)) return 'encarregado'
   if (d === 'QSMA' || d === 'TST' || /SEGURAN/.test(c)) return 'apoio'
+  if (/LIMPEZA|SERVI[CÇ]OS GERAIS|COPEIR|JARDINEIR/.test(c)) return 'apoio'  // não entram no time
   return 'time'
 }
 


### PR DESCRIPTION
papelSugerido passa a classificar limpeza/serviços gerais/copeira/jardineiro como Apoio, então não aparecem no roster Time da composição.

🤖 Generated with [Claude Code](https://claude.com/claude-code)