### PR TITLE
feat(monitoramento): módulo CFTV (Hikvision) no pilar IT + remove AI Agents

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,8 @@ import EstoqueLayout from './components/EstoqueLayout'
 import LogisticaLayout from './components/LogisticaLayout'
 import TiLayout from './pages/ti/TiLayout'
 import { TiStaffRoute, TiAdminRoute } from './pages/ti/components/TiGuards'
+import MonLayout from './pages/monitoramento/MonLayout'
+import { MonAdminRoute } from './pages/monitoramento/MonGuards'
 import FrotasLayout from './components/FrotasLayout'
 import CulturaLayout from './components/CulturaLayout'
 import HeadcountLayout from './components/HeadcountLayout'
@@ -259,6 +261,11 @@ const TiRespostas = lazy(() => import('./pages/ti/Respostas'))
 const TiUsuarios = lazy(() => import('./pages/ti/Usuarios'))
 const MeusChamadosPessoal = lazy(() => import('./pages/ti/MeusChamadosPessoal'))
 
+// Monitoramento (CFTV Hikvision) — gated pelo módulo 'monitoramento'
+const MonCameras = lazy(() => import('./pages/monitoramento/Cameras'))
+const MonEventos = lazy(() => import('./pages/monitoramento/Eventos'))
+const MonConfig = lazy(() => import('./pages/monitoramento/Config'))
+
 // Orçamentação (Expansão)
 const OrcamentacaoHome = lazy(() => import('./pages/orcamentacao/OrcamentacaoHome'))
 const OrcamentosLista = lazy(() => import('./pages/orcamentacao/OrcamentosLista'))
@@ -335,6 +342,20 @@ export default function App() {
               <Route element={<TiAdminRoute />}>
                 <Route path="/ti/usuarios" element={<Lazy><TiUsuarios /></Lazy>} />
                 <Route path="/ti/configuracoes" element={<Lazy><TiConfiguracoes /></Lazy>} />
+              </Route>
+            </Route>
+          </Route>
+        </Route>
+
+        {/* ── Monitoramento (CFTV Hikvision): exige o módulo 'monitoramento'
+             liberado (admin sempre entra). Config só admin. ── */}
+        <Route element={<PrivateRoute />}>
+          <Route element={<ModuleRoute moduleKey="monitoramento" />}>
+            <Route element={<MonLayout />}>
+              <Route path="/monitoramento" element={<Lazy><MonCameras /></Lazy>} />
+              <Route path="/monitoramento/eventos" element={<Lazy><MonEventos /></Lazy>} />
+              <Route element={<MonAdminRoute />}>
+                <Route path="/monitoramento/config" element={<Lazy><MonConfig /></Lazy>} />
               </Route>
             </Route>
           </Route>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -223,6 +223,7 @@ export const MODULOS_ERP_GROUPED: GrupoModulos[] = [
     label: 'TI',
     modulos: [
       { key: 'ti', label: 'TI (Helpdesk)', icon: '🖥️' },
+      { key: 'monitoramento', label: 'Monitoramento (CFTV)', icon: '🎥' },
     ],
   },
 ]

--- a/frontend/src/pages/ModuloSelector.tsx
+++ b/frontend/src/pages/ModuloSelector.tsx
@@ -7,7 +7,7 @@ import {
   // Sub-module icons
   Settings, HardHat, ShieldCheck, ShoppingCart, Truck,
   Package, Building2, Car, Banknote, BarChart3, FileText, KeySquare,
-  UserCog, UserSearch, Server, Bot, Target, Store, Receipt, CreditCard, Heart, Calculator, Laptop, Moon, Sun, Scale, ClipboardCheck, LayoutDashboard, Headset, ChevronRight, ChevronLeft,
+  UserCog, UserSearch, Server, Target, Store, Receipt, CreditCard, Heart, Calculator, Laptop, Moon, Sun, Scale, ClipboardCheck, LayoutDashboard, Headset, ChevronRight, ChevronLeft, Video,
   type LucideIcon,
 } from 'lucide-react'
 import { useAuth } from '../contexts/AuthContext'
@@ -145,7 +145,7 @@ const PILLARS: Pillar[] = [
     accent: '#38BDF8',
     subs: [
       { key: 'ti', label: 'TI', desc: 'Chamados, suporte e infraestrutura', Icon: Server, active: true, route: '/ti' },
-      { key: 'ai', label: 'AI Agents', desc: 'Agentes inteligentes TEG+', Icon: Bot, active: false, route: '' },
+      { key: 'monitoramento', label: 'Monitoramento', desc: 'Câmeras (CFTV) e eventos', Icon: Video, active: true, route: '/monitoramento' },
     ],
   },
   {

--- a/frontend/src/pages/monitoramento/Cameras.tsx
+++ b/frontend/src/pages/monitoramento/Cameras.tsx
@@ -1,0 +1,104 @@
+// Câmeras — grade de vídeo ao vivo. O player embute o go2rtc (MSE/WebRTC) do
+// gateway on-prem, cuja URL fica em mon_config. Enquanto não houver gateway ou
+// stream_key, mostra um placeholder — a estrutura já funciona, o vídeo "acende"
+// quando o worker/go2rtc on-prem estiver configurado.
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
+import { Video, VideoOff, Settings, AlertTriangle } from 'lucide-react'
+import { listCameras, getGo2rtcUrl } from './data/cameras'
+import type { Camera } from './data/types'
+import { useAuth } from '../../contexts/AuthContext'
+
+function CameraTile({ cam, baseUrl }: { cam: Camera; baseUrl: string }) {
+  const ready = !!baseUrl && !!cam.streamKey
+  const src = ready ? `${baseUrl}/stream.html?src=${encodeURIComponent(cam.streamKey!)}&mode=mse,webrtc` : ''
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-200 bg-slate-900 shadow-sm">
+      <div className="aspect-video w-full bg-slate-950">
+        {ready ? (
+          <iframe src={src} title={cam.nome} className="h-full w-full border-0" allow="autoplay; fullscreen" />
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center gap-2 text-slate-500">
+            <VideoOff className="h-8 w-8" />
+            <span className="text-xs">{!baseUrl ? 'Gateway não configurado' : 'Sem stream vinculado'}</span>
+          </div>
+        )}
+      </div>
+      <div className="flex items-center justify-between gap-2 bg-white px-3 py-2">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-semibold text-slate-800">{cam.nome}</div>
+          {cam.local && <div className="truncate text-xs text-slate-400">{cam.local}</div>}
+        </div>
+        <span className={`h-2 w-2 shrink-0 rounded-full ${ready ? 'bg-emerald-500' : 'bg-slate-300'}`} />
+      </div>
+    </div>
+  )
+}
+
+export default function Cameras() {
+  const { isAdmin } = useAuth()
+  const camsQ = useQuery({ queryKey: ['mon', 'cameras'], queryFn: () => listCameras(false) })
+  const urlQ = useQuery({ queryKey: ['mon', 'go2rtc'], queryFn: getGo2rtcUrl })
+  const cams = camsQ.data ?? []
+  const baseUrl = urlQ.data ?? ''
+
+  return (
+    <div>
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-bold text-slate-800">Câmeras</h1>
+          <p className="mt-0.5 text-sm text-slate-500">Monitoramento ao vivo (CFTV)</p>
+        </div>
+        {isAdmin && (
+          <Link to="/monitoramento/config" className="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50">
+            <Settings className="h-4 w-4" /> Configurar
+          </Link>
+        )}
+      </div>
+
+      {urlQ.isError && (
+        <div className="mb-4 rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700">
+          Não foi possível verificar o gateway de vídeo. Verifique sua conexão e tente novamente.
+        </div>
+      )}
+
+      {!urlQ.isError && !baseUrl && cams.length > 0 && (
+        <div className="mb-4 rounded-lg bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          O gateway de vídeo (go2rtc) ainda não foi configurado — as câmeras aparecem, mas o vídeo ao vivo só liga após configurar o gateway on-prem.{' '}
+          {isAdmin && <Link to="/monitoramento/config" className="font-semibold underline">Configurar agora</Link>}
+        </div>
+      )}
+
+      {camsQ.isLoading ? (
+        <div className="py-16 text-center text-slate-400">Carregando…</div>
+      ) : camsQ.isError ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 py-16 text-center">
+          <AlertTriangle className="mx-auto mb-3 h-10 w-10 text-red-300" />
+          <p className="font-semibold text-red-700">Não foi possível carregar as câmeras</p>
+          <p className="mx-auto mt-1 max-w-md text-sm text-red-600">Verifique sua conexão e tente novamente.</p>
+          <button
+            onClick={() => camsQ.refetch()}
+            disabled={camsQ.isFetching}
+            className="mt-4 inline-flex items-center gap-2 rounded-lg border border-red-300 bg-white px-4 py-2 text-sm font-semibold text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {camsQ.isFetching ? 'Tentando…' : 'Tentar novamente'}
+          </button>
+        </div>
+      ) : cams.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-slate-300 bg-white py-16 text-center">
+          <Video className="mx-auto mb-3 h-10 w-10 text-slate-300" />
+          <p className="font-semibold text-slate-700">Nenhuma câmera cadastrada</p>
+          <p className="mt-1 text-sm text-slate-500">
+            {isAdmin
+              ? <>Cadastre as câmeras em <Link to="/monitoramento/config" className="font-medium text-indigo-600 hover:underline">Configurações</Link>.</>
+              : 'Aguarde o administrador cadastrar as câmeras.'}
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {cams.map((c) => <CameraTile key={c.id} cam={c} baseUrl={baseUrl} />)}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/monitoramento/Config.tsx
+++ b/frontend/src/pages/monitoramento/Config.tsx
@@ -1,0 +1,105 @@
+// Configurações (admin) — URL do gateway go2rtc + cadastro de câmeras.
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Plus, Trash2, Save } from 'lucide-react'
+import { listCameras, createCamera, updateCamera, deleteCamera, getGo2rtcUrl, setGo2rtcUrl } from './data/cameras'
+import type { Camera } from './data/types'
+
+const inputCls = 'w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200'
+const btnPrimary = 'inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-60'
+
+function GatewayPanel() {
+  const qc = useQueryClient()
+  const { data } = useQuery({ queryKey: ['mon', 'go2rtc'], queryFn: getGo2rtcUrl })
+  const [draft, setDraft] = useState<string | null>(null)
+  const value = draft ?? data ?? ''
+  const mut = useMutation({
+    mutationFn: () => setGo2rtcUrl(value),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['mon', 'go2rtc'] }),
+  })
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-5">
+      <h2 className="mb-1 text-sm font-semibold text-slate-700">Gateway de vídeo (go2rtc)</h2>
+      <p className="mb-3 text-xs text-slate-500">
+        URL pública (túnel HTTPS) do go2rtc que roda na máquina on-prem. Ex.: <code>https://cameras.suaempresa.com</code>
+      </p>
+      <div className="flex flex-wrap items-center gap-2">
+        <input className={`${inputCls} flex-1`} value={value} onChange={(e) => setDraft(e.target.value)} placeholder="https://cameras.suaempresa.com" />
+        <button className={btnPrimary} disabled={mut.isPending} onClick={() => mut.mutate()}><Save className="h-4 w-4" /> {mut.isPending ? 'Salvando…' : 'Salvar'}</button>
+      </div>
+      {mut.isError && <p className="mt-2 text-xs text-red-600">Não foi possível salvar a URL. Tente novamente.</p>}
+      {mut.isSuccess && !mut.isPending && <p className="mt-2 text-xs text-emerald-600">URL salva.</p>}
+    </div>
+  )
+}
+
+function CameraRow({ cam, onChanged }: { cam: Camera; onChanged: () => void }) {
+  const [nome, setNome] = useState(cam.nome)
+  const [local, setLocal] = useState(cam.local ?? '')
+  const [canal, setCanal] = useState(String(cam.canal))
+  const [streamKey, setStreamKey] = useState(cam.streamKey ?? '')
+  const save = useMutation({
+    mutationFn: () => updateCamera(cam.id, { nome: nome.trim(), local: local.trim() || null, canal: Number(canal) || 1, streamKey: streamKey.trim() || null }),
+    onSuccess: onChanged,
+  })
+  const toggle = useMutation({ mutationFn: () => updateCamera(cam.id, { ativo: !cam.ativo }), onSuccess: onChanged })
+  const del = useMutation({ mutationFn: () => deleteCamera(cam.id), onSuccess: onChanged })
+  const busy = save.isPending || toggle.isPending || del.isPending
+  const erro = save.isError || toggle.isError || del.isError
+  return (
+    <div className="border-t border-slate-100 py-3">
+      <div className="grid grid-cols-1 gap-2 md:grid-cols-[1.4fr_1.2fr_0.5fr_1.2fr_auto]">
+        <input className={inputCls} value={nome} onChange={(e) => setNome(e.target.value)} placeholder="Nome" />
+        <input className={inputCls} value={local} onChange={(e) => setLocal(e.target.value)} placeholder="Local" />
+        <input className={inputCls} value={canal} onChange={(e) => setCanal(e.target.value)} placeholder="Canal" />
+        <input className={inputCls} value={streamKey} onChange={(e) => setStreamKey(e.target.value)} placeholder="stream_key (go2rtc)" />
+        <div className="flex items-center gap-1">
+          <button disabled={busy} className="rounded-lg px-2 py-1 text-xs font-semibold text-slate-500 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50" onClick={() => toggle.mutate()}>{cam.ativo ? 'Ativa' : 'Inativa'}</button>
+          <button disabled={busy} className="rounded-lg bg-indigo-600 px-2.5 py-1.5 text-xs font-semibold text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50" onClick={() => save.mutate()}>{save.isPending ? 'Salvando…' : 'Salvar'}</button>
+          <button disabled={busy} className="rounded-lg p-1.5 text-slate-400 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-50" onClick={() => { if (window.confirm(`Excluir a câmera "${cam.nome}"?`)) del.mutate() }} aria-label="Excluir"><Trash2 className="h-4 w-4" /></button>
+        </div>
+      </div>
+      {erro && <p className="mt-1.5 text-xs text-red-600">Não foi possível concluir a operação. Tente novamente.</p>}
+    </div>
+  )
+}
+
+export default function Config() {
+  const qc = useQueryClient()
+  const { data } = useQuery({ queryKey: ['mon', 'cameras', 'all'], queryFn: () => listCameras(true) })
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['mon', 'cameras'] })
+    qc.invalidateQueries({ queryKey: ['mon', 'cameras', 'all'] })
+  }
+  const [nome, setNome] = useState('')
+  const add = useMutation({ mutationFn: () => createCamera({ nome: nome.trim(), canal: 1 }), onSuccess: () => { setNome(''); invalidate() } })
+  const cams = data ?? []
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-bold text-slate-800">Configurações</h1>
+        <p className="mt-0.5 text-sm text-slate-500">Gateway de vídeo e cadastro de câmeras</p>
+      </div>
+
+      <GatewayPanel />
+
+      <div className="rounded-xl border border-slate-200 bg-white p-5">
+        <h2 className="mb-3 text-sm font-semibold text-slate-700">Câmeras</h2>
+        <div className="mb-1 flex flex-wrap gap-2">
+          <input className={`${inputCls} min-w-[200px] flex-1`} value={nome} onChange={(e) => setNome(e.target.value)} placeholder="Nome da nova câmera" />
+          <button className={btnPrimary} disabled={!nome.trim() || add.isPending} onClick={() => add.mutate()}><Plus className="h-4 w-4" /> {add.isPending ? 'Adicionando…' : 'Adicionar'}</button>
+        </div>
+        {add.isError && <p className="mb-1 text-xs text-red-600">Não foi possível adicionar a câmera. Tente novamente.</p>}
+        {cams.length === 0 ? (
+          <p className="py-6 text-center text-sm text-slate-400">Nenhuma câmera. Adicione a primeira acima.</p>
+        ) : (
+          <div>{cams.map((c) => <CameraRow key={c.id} cam={c} onChanged={invalidate} />)}</div>
+        )}
+        <p className="mt-3 text-xs text-slate-400">
+          O <b>stream_key</b> deve bater com o nome do stream no go2rtc (arquivo YAML do gateway on-prem). O <b>canal</b> é o número do canal no NVR.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/monitoramento/Eventos.tsx
+++ b/frontend/src/pages/monitoramento/Eventos.tsx
@@ -1,0 +1,88 @@
+// Eventos — timeline dos alertas das câmeras (motion, intrusão, linha cruzada…),
+// com atualização em tempo real (Supabase Realtime). O worker on-prem popula
+// mon_eventos; aqui só lemos.
+import { useEffect } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { Bell, User, Car, AlertTriangle } from 'lucide-react'
+import { listEventos, subscribeEventos } from './data/eventos'
+
+const TIPO_LABEL: Record<string, string> = {
+  motion: 'Movimento',
+  VMD: 'Movimento',
+  linedetection: 'Linha cruzada',
+  fielddetection: 'Intrusão',
+  regionEntrance: 'Entrada em área',
+  regionExiting: 'Saída de área',
+  tamperdetection: 'Sabotagem',
+  videoloss: 'Perda de vídeo',
+  facedetection: 'Rosto detectado',
+}
+const tipoLabel = (t: string) => TIPO_LABEL[t] ?? t
+
+export default function Eventos() {
+  const qc = useQueryClient()
+  const { data, isLoading, isError, refetch, isFetching } = useQuery({ queryKey: ['mon', 'eventos'], queryFn: () => listEventos(100) })
+  useEffect(
+    () => subscribeEventos(() => qc.invalidateQueries({ queryKey: ['mon', 'eventos'] })),
+    [qc],
+  )
+  const eventos = data ?? []
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-slate-800">Eventos</h1>
+        <p className="mt-0.5 text-sm text-slate-500">Alertas das câmeras em tempo real</p>
+      </div>
+
+      {isLoading ? (
+        <div className="py-16 text-center text-slate-400">Carregando…</div>
+      ) : isError ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 py-16 text-center">
+          <AlertTriangle className="mx-auto mb-3 h-10 w-10 text-red-300" />
+          <p className="font-semibold text-red-700">Não foi possível carregar os eventos</p>
+          <p className="mx-auto mt-1 max-w-md text-sm text-red-600">Verifique sua conexão e tente novamente.</p>
+          <button
+            onClick={() => refetch()}
+            disabled={isFetching}
+            className="mt-4 inline-flex items-center gap-2 rounded-lg border border-red-300 bg-white px-4 py-2 text-sm font-semibold text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isFetching ? 'Tentando…' : 'Tentar novamente'}
+          </button>
+        </div>
+      ) : eventos.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-slate-300 bg-white py-16 text-center">
+          <Bell className="mx-auto mb-3 h-10 w-10 text-slate-300" />
+          <p className="font-semibold text-slate-700">Nenhum evento ainda</p>
+          <p className="mx-auto mt-1 max-w-md text-sm text-slate-500">
+            Os eventos (movimento, intrusão, linha cruzada) aparecem aqui em tempo real assim que o serviço on-prem estiver conectado ao NVR.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
+          <ul className="divide-y divide-slate-100">
+            {eventos.map((e) => (
+              <li key={e.id} className="flex items-center gap-3 px-4 py-3 hover:bg-slate-50">
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600">
+                  <AlertTriangle className="h-4 w-4" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-semibold text-slate-800">
+                    {tipoLabel(e.tipo)}{e.cameraNome ? ` · ${e.cameraNome}` : ''}
+                  </div>
+                  <div className="text-xs text-slate-400">{new Date(e.ocorreuEm).toLocaleString('pt-BR')}</div>
+                </div>
+                {e.alvo === 'human' && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-rose-50 px-2 py-0.5 text-xs font-medium text-rose-600"><User className="h-3 w-3" /> Pessoa</span>
+                )}
+                {e.alvo === 'vehicle' && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-sky-50 px-2 py-0.5 text-xs font-medium text-sky-600"><Car className="h-3 w-3" /> Veículo</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/monitoramento/MonGuards.tsx
+++ b/frontend/src/pages/monitoramento/MonGuards.tsx
@@ -1,0 +1,10 @@
+// Guard de rota do módulo Monitoramento. O acesso ao módulo (hasModule) é
+// garantido antes pelo ModuleRoute; aqui restringimos a Configuração ao admin.
+import { Navigate, Outlet } from 'react-router-dom'
+import { useAuth } from '../../contexts/AuthContext'
+
+export function MonAdminRoute() {
+  const { isAdmin } = useAuth()
+  if (!isAdmin) return <Navigate to="/monitoramento" replace />
+  return <Outlet />
+}

--- a/frontend/src/pages/monitoramento/MonLayout.tsx
+++ b/frontend/src/pages/monitoramento/MonLayout.tsx
@@ -1,0 +1,27 @@
+// Layout (shell + nav) do módulo Monitoramento (CFTV) — wrapper sobre o
+// ModuleLayout padrão do TEG+. disableRequisitanteMode: todos com o módulo são
+// "viewers" (não há fluxo de requisitante aqui).
+import { Video, Bell, Settings } from 'lucide-react'
+import ModuleLayout from '../../components/ModuleLayout'
+import type { NavItem } from '../../components/ModuleLayout'
+
+const NAV: NavItem[] = [
+  { to: '/monitoramento', icon: Video, label: 'Câmeras', end: true },
+  { to: '/monitoramento/eventos', icon: Bell, label: 'Eventos', end: false },
+  { to: '/monitoramento/config', icon: Settings, label: 'Configurações', end: false, adminOnly: true },
+]
+
+export default function MonLayout() {
+  return (
+    <ModuleLayout
+      moduleKey="monitoramento"
+      moduleName="Monitoramento"
+      moduleEmoji="🎥"
+      accent="indigo"
+      nav={NAV}
+      moduleSubtitle="Câmeras e eventos (CFTV)"
+      maxWidth="max-w-7xl"
+      disableRequisitanteMode
+    />
+  )
+}

--- a/frontend/src/pages/monitoramento/data/cameras.ts
+++ b/frontend/src/pages/monitoramento/data/cameras.ts
@@ -1,0 +1,87 @@
+// Câmeras (mon_cameras) + config do gateway (mon_config). Supabase-nativo.
+import { supabase } from './supabase'
+import type { Camera } from './types'
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const toCamera = (r: any): Camera => ({
+  id: r.id,
+  nome: r.nome,
+  local: r.local ?? null,
+  canal: r.canal,
+  nvrNome: r.nvr_nome ?? null,
+  streamKey: r.stream_key ?? null,
+  ptz: r.ptz,
+  ordem: r.ordem ?? 0,
+  ativo: r.ativo,
+  observacoes: r.observacoes ?? null,
+})
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+export async function listCameras(all = false): Promise<Camera[]> {
+  let query = supabase.from('mon_cameras').select('*').order('ordem', { ascending: true }).order('nome', { ascending: true })
+  if (!all) query = query.eq('ativo', true)
+  const { data, error } = await query
+  if (error) throw error
+  return (data ?? []).map(toCamera)
+}
+
+export interface CameraInput {
+  nome: string
+  local?: string | null
+  canal: number
+  nvrNome?: string | null
+  streamKey?: string | null
+  ptz?: boolean
+  ativo?: boolean
+  observacoes?: string | null
+}
+
+export async function createCamera(input: CameraInput): Promise<void> {
+  const { count } = await supabase.from('mon_cameras').select('id', { count: 'exact', head: true })
+  const { error } = await supabase.from('mon_cameras').insert({
+    nome: input.nome,
+    local: input.local ?? null,
+    canal: input.canal,
+    nvr_nome: input.nvrNome ?? null,
+    stream_key: input.streamKey ?? null,
+    ptz: input.ptz ?? false,
+    ativo: input.ativo ?? true,
+    observacoes: input.observacoes ?? null,
+    ordem: count ?? 0,
+  })
+  if (error) throw error
+}
+
+export async function updateCamera(id: string, patch: Partial<CameraInput>): Promise<void> {
+  const db: Record<string, unknown> = {}
+  if (patch.nome !== undefined) db.nome = patch.nome
+  if (patch.local !== undefined) db.local = patch.local
+  if (patch.canal !== undefined) db.canal = patch.canal
+  if (patch.nvrNome !== undefined) db.nvr_nome = patch.nvrNome
+  if (patch.streamKey !== undefined) db.stream_key = patch.streamKey
+  if (patch.ptz !== undefined) db.ptz = patch.ptz
+  if (patch.ativo !== undefined) db.ativo = patch.ativo
+  if (patch.observacoes !== undefined) db.observacoes = patch.observacoes
+  db.updated_at = new Date().toISOString()
+  const { error } = await supabase.from('mon_cameras').update(db).eq('id', id)
+  if (error) throw error
+}
+
+export async function deleteCamera(id: string): Promise<void> {
+  const { error } = await supabase.from('mon_cameras').delete().eq('id', id)
+  if (error) throw error
+}
+
+// Config do gateway go2rtc (URL base pública do túnel HTTPS)
+export async function getGo2rtcUrl(): Promise<string> {
+  const { data, error } = await supabase.from('mon_config').select('go2rtc_url').eq('id', 1).maybeSingle()
+  if (error) throw error
+  return (data?.go2rtc_url ?? '').replace(/\/+$/, '')
+}
+
+export async function setGo2rtcUrl(url: string): Promise<void> {
+  const { error } = await supabase.from('mon_config')
+    .update({ go2rtc_url: url.trim() || null, updated_at: new Date().toISOString() })
+    .eq('id', 1)
+  if (error) throw error
+}

--- a/frontend/src/pages/monitoramento/data/eventos.ts
+++ b/frontend/src/pages/monitoramento/data/eventos.ts
@@ -1,0 +1,42 @@
+// Eventos (mon_eventos). O worker on-prem insere via service-role; aqui só leitura
+// + assinatura Realtime para alertas ao vivo.
+import { supabase } from './supabase'
+import type { MonEvento } from './types'
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const toEvento = (r: any): MonEvento => ({
+  id: r.id,
+  cameraId: r.camera_id ?? null,
+  cameraNome: (Array.isArray(r.camera) ? r.camera[0]?.nome : r.camera?.nome) ?? null,
+  canal: r.canal ?? null,
+  tipo: r.tipo,
+  alvo: r.alvo ?? null,
+  estado: r.estado ?? null,
+  snapshotPath: r.snapshot_path ?? null,
+  ocorreuEm: r.ocorreu_em,
+})
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+export async function listEventos(limit = 100): Promise<MonEvento[]> {
+  const { data, error } = await supabase
+    .from('mon_eventos')
+    .select('id, camera_id, canal, tipo, alvo, estado, snapshot_path, ocorreu_em, camera:mon_cameras!mon_eventos_camera_id_fkey(nome)')
+    .order('ocorreu_em', { ascending: false })
+    .limit(limit)
+  if (error) throw error
+  return (data ?? []).map(toEvento)
+}
+
+/** Assina novos eventos (Realtime). Retorna a função de limpeza. */
+export function subscribeEventos(onInsert: () => void): () => void {
+  const ch = supabase
+    .channel('mon-eventos')
+    .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'mon_eventos' }, onInsert)
+    .subscribe()
+  return () => { supabase.removeChannel(ch) }
+}
+
+export async function snapshotUrl(path: string): Promise<string> {
+  const { data } = await supabase.storage.from('mon-evidencias').createSignedUrl(path, 60 * 60)
+  return data?.signedUrl ?? ''
+}

--- a/frontend/src/pages/monitoramento/data/supabase.ts
+++ b/frontend/src/pages/monitoramento/data/supabase.ts
@@ -1,0 +1,3 @@
+// Ponto único de acesso ao Supabase dentro do módulo Monitoramento.
+// Reexporta o singleton global do app — nunca criar outro client aqui.
+export { supabase } from '../../../services/supabase'

--- a/frontend/src/pages/monitoramento/data/types.ts
+++ b/frontend/src/pages/monitoramento/data/types.ts
@@ -1,0 +1,24 @@
+export interface Camera {
+  id: string
+  nome: string
+  local: string | null
+  canal: number
+  nvrNome: string | null
+  streamKey: string | null
+  ptz: boolean
+  ordem: number
+  ativo: boolean
+  observacoes: string | null
+}
+
+export interface MonEvento {
+  id: string
+  cameraId: string | null
+  cameraNome: string | null
+  canal: number | null
+  tipo: string
+  alvo: string | null      // human | vehicle | null
+  estado: string | null    // active | inactive
+  snapshotPath: string | null
+  ocorreuEm: string
+}

--- a/monitoramento-gateway/README.md
+++ b/monitoramento-gateway/README.md
@@ -1,0 +1,104 @@
+# TEG+ · Monitoramento — Gateway on-prem (go2rtc)
+
+Guia para ligar as câmeras Hikvision (via NVR) ao módulo **Monitoramento** do TEG+,
+usando uma máquina na **mesma rede do NVR**. O ERP já está pronto — falta só o
+gateway de vídeo.
+
+```
+Câmeras ──► NVR (rede local, IP tipo 192.168.x.x)
+                │  RTSP (vídeo)
+                ▼
+        PC on-prem ── go2rtc (converte p/ o navegador)
+                │  túnel HTTPS (Cloudflare)
+                ▼
+        TEG+ /monitoramento  (cola a URL do túnel em Configurações)
+```
+
+> 🔒 **Segurança (importante):** o NVR/câmeras **nunca** devem ser expostos direto
+> na internet (nada de port-forward para eles). Só o `go2rtc` sai por HTTPS via
+> túnel. Crie um **usuário dedicado** no NVR (perfil de operador/visualização),
+> nunca o admin. Ideal: câmeras/NVR numa VLAN isolada.
+
+---
+
+## Pré-requisitos
+
+1. Um **PC/mini-PC sempre-ligado** na **mesma rede local do NVR** (pode ser o
+   mesmo do worker do WhatsApp). Windows serve.
+2. O **IP local do NVR** (ex.: `192.168.0.10`) e **RTSP habilitado** no NVR.
+3. Um **usuário dedicado** no NVR com permissão de visualização/RTSP.
+4. Saber os **canais** das câmeras (câmera 1 = 101/102, câmera 2 = 201/202…).
+
+---
+
+## Passo 1 — Instalar o go2rtc
+
+1. Baixe o `go2rtc_win64.zip` em https://github.com/AlexxIT/go2rtc/releases
+2. Extraia numa pasta, ex.: `C:\teg\go2rtc\`
+3. Copie o `go2rtc.yaml.example` (deste repositório) para essa pasta como
+   **`go2rtc.yaml`** e preencha IP/usuário/senha do NVR e as linhas das câmeras.
+4. Rode `go2rtc.exe` (duplo-clique ou pelo PowerShell).
+5. Teste local: abra `http://localhost:1984` — deve listar as câmeras e tocar o
+   vídeo. Se não tocar, confira o RTSP (veja "Solução de problemas").
+
+> **Codec:** configure o **sub-stream** das câmeras em **H.264** (não H.265+/
+> H.264+ "smart codec") no NVR — garante que o navegador toca sem transcodificar.
+
+## Passo 2 — Expor por HTTPS (Cloudflare Tunnel)
+
+O go2rtc só está em `localhost`. Para o ERP (na Vercel) alcançar, use um túnel.
+
+**Teste rápido (URL temporária):**
+```powershell
+# baixe cloudflared: https://github.com/cloudflare/cloudflared/releases
+cloudflared tunnel --url http://localhost:1984
+```
+Ele imprime uma URL `https://algo.trycloudflare.com` — já dá pra testar no ERP.
+
+**Produção (URL fixa, recomendado):** com uma conta Cloudflare + um domínio de
+vocês, crie um túnel nomeado e aponte um hostname (ex.: `cameras.teguniao.com.br`)
+para `http://localhost:1984`. Passo a passo:
+https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
+
+> ⚠️ O acesso remoto usa **MSE** (o player do ERP já pede `mode=mse,webrtc`), que
+> passa pelo túnel HTTPS. WebRTC puro (UDP) **não** passa por túnel — mas MSE
+> entrega ~1s de latência, ótimo para monitoramento.
+
+## Passo 3 — Conectar no ERP
+
+1. No TEG+, entre como **admin** em **/monitoramento → Configurações**.
+2. Cole a **URL do túnel** (ex.: `https://cameras.teguniao.com.br`) no campo
+   *Gateway de vídeo (go2rtc)* e salve.
+3. Ainda em Configurações, **cadastre cada câmera**: nome, local, canal e o
+   **stream_key** = o nome do stream no `go2rtc.yaml` (ex.: `cam1`).
+4. Vá em **Câmeras** → o vídeo ao vivo aparece na grade. ✅
+
+## Deixar sempre ligado (Windows)
+
+Registre o go2rtc (e o cloudflared) como serviço com **NSSM** ou **WinSW** para
+subirem no boot. Ex. com NSSM:
+```powershell
+nssm install teg-go2rtc "C:\teg\go2rtc\go2rtc.exe"
+nssm start teg-go2rtc
+```
+
+---
+
+## Solução de problemas
+
+- **Vídeo não toca no go2rtc local:** teste o RTSP no VLC (`Mídia → Abrir fluxo de
+  rede` com a mesma URL). Se o VLC não toca, é credencial/canal/RTSP do NVR.
+- **Toca local mas não remoto:** confirme o túnel ativo e que no ERP o modo é MSE
+  (já é o padrão). WebRTC não passa por túnel.
+- **Trava/CPU alta:** use o **sub-stream** (102/202…) na grade e H.264 (não H.265+).
+- **Usuário bloqueado no NVR:** 5 senhas erradas bloqueiam o admin por 30 min —
+  por isso use um usuário dedicado e confira a senha no `go2rtc.yaml`.
+
+---
+
+## O que vem depois (Fase 3 — eventos)
+
+Ver ao vivo é só o go2rtc (acima). Os **eventos** (movimento, intrusão, linha
+cruzada → aba *Eventos* do ERP) precisam de um **worker Node** que escuta o NVR
+via ISAPI e grava em `mon_eventos`. Esse worker será entregue aqui neste diretório
+quando partirmos para a Fase 3 (mesmo padrão do worker do WhatsApp).

--- a/monitoramento-gateway/go2rtc.yaml.example
+++ b/monitoramento-gateway/go2rtc.yaml.example
@@ -1,0 +1,29 @@
+# Configuração do go2rtc — gateway de vídeo do módulo Monitoramento (TEG+).
+# Roda na máquina on-prem (mesma rede do NVR). Copie para "go2rtc.yaml",
+# preencha IP/usuário/senha do NVR e uma linha por câmera.
+#
+# Convenção de canal Hikvision no NVR:
+#   Câmera 1 → 101 (main / alta) | 102 (sub / leve)
+#   Câmera 2 → 201 | 202
+#   Câmera 3 → 301 | 302  ...
+# Para a GRADE do ERP use o SUB-stream (102, 202...) — mais leve. Detalhe/tela
+# cheia pode usar o main (101...). O NOME do stream (ex.: "cam1") é o que você
+# digita no campo "stream_key" da câmera em /monitoramento (Configurações).
+
+streams:
+  cam1: rtsp://USUARIO:SENHA@IP_DO_NVR:554/Streaming/Channels/102
+  cam2: rtsp://USUARIO:SENHA@IP_DO_NVR:554/Streaming/Channels/202
+  cam3: rtsp://USUARIO:SENHA@IP_DO_NVR:554/Streaming/Channels/302
+  # ...uma linha por câmera
+
+# API/web do go2rtc (porta 1984) — é o que o túnel HTTPS vai expor.
+api:
+  listen: ":1984"
+
+# WebRTC (porta 8555) — funciona só na rede local; para acesso remoto o ERP
+# usa MSE (que passa pelo túnel HTTPS). Deixe como está.
+webrtc:
+  listen: ":8555"
+
+log:
+  level: info


### PR DESCRIPTION
## Resumo

Adiciona o módulo **Monitoramento (CFTV Hikvision)** ao pilar **IT** do TEG+ e **remove o card "AI Agents"**. Módulo Supabase-nativo, liberado por **permissão** ('monitoramento'); o banco já está em produção.

## O que muda

- **Pilar IT** (`ModuloSelector`): novo card **"Monitoramento"** (gated por `hasModule('monitoramento')`); card **"AI Agents" removido** (ícone `Bot`→`Video`).
- **Rotas** (`App.tsx`): `/monitoramento` (câmeras ao vivo), `/monitoramento/eventos` (timeline em tempo real), `/monitoramento/config` (admin: URL do go2rtc + CRUD de câmeras) — sob `PrivateRoute` + `ModuleRoute('monitoramento')` + `MonLayout`; config sob `MonAdminRoute`.
- **AuthContext**: módulo `'monitoramento'` no grupo TI de `MODULOS_ERP_GROUPED` (checkbox em `/admin/usuarios`).
- **`monitoramento-gateway/`**: guia on-prem (go2rtc + Cloudflare Tunnel) para habilitar o vídeo ao vivo.

## Notas para o revisor

- **Migração de banco já aplicada** ao Supabase de produção (`mon_config`/`mon_cameras`/`mon_eventos`, RLS, `mon_pode_ver()`, bucket `mon-evidencias`, realtime).
- **Revisão adversarial** (workflow, 8 agentes): a camada de dados **confere com o schema de produção** (sem drift); 2 achados de UX corrigidos — Câmeras/Eventos tratam `isError` (estado de erro em vez de "vazio" enganoso) e as mutations da Config dão feedback + desabilitam durante o pending.
- **Vídeo ao vivo depende do gateway on-prem** (go2rtc + túnel) — ver `monitoramento-gateway/README.md`. Sem ele, as câmeras aparecem como placeholder; o restante (cadastrar câmeras, configurar gateway) já funciona.
- A aba **Eventos** fica vazia até o worker de eventos (ISAPI `alertStream`→`mon_eventos`) ser construído/ativado — comportamento correto.
- O módulo é **gated por permissão**: não aparece para quem não tem o módulo liberado (admin sempre vê).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
