### PR TITLE
fix(ti): remove o botão "+ Nova Solicitação" do cabeçalho da aba Chamados

### DIFF
--- a/frontend/src/pages/ti/Chamados.tsx
+++ b/frontend/src/pages/ti/Chamados.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { Search, Plus, Inbox, AlertTriangle, ChevronLeft, Headset, CheckCircle2, Package, X } from 'lucide-react'
+import { Search, Inbox, AlertTriangle, ChevronLeft, Headset, CheckCircle2, Package, X } from 'lucide-react'
 import { NovoChamadoForm } from './NovoChamado'
 import { listCategories, listSectors } from './data/meta'
 import { listTickets, type TicketFilters } from './data/tickets'
@@ -44,10 +44,10 @@ function ChamadosStaff() {
 
   return (
     <div className="ti-scope">
+      {/* Sem botão de ação: abrir chamado é pelo item "Nova Solicitação" do menu lateral */}
       <PageHeader
         title={staff ? 'Chamados' : 'Meus Chamados'}
         subtitle={staff ? 'Todos os chamados da T.I.' : 'Chamados que você abriu'}
-        action={<Link to="/ti/chamados/novo" className="btn-primary"><Plus className="h-4 w-4" /> Nova Solicitação</Link>}
       />
 
       <TiTabs />


### PR DESCRIPTION
## Resumo

Remove o botão **"+ Nova Solicitação"** do cabeçalho da aba **Chamados** do Helpdesk TEG, a pedido.

## Detalhes

- O `action` do `PageHeader` em `Chamados.tsx` foi removido. Abrir chamado continua disponível pelo item **"Nova Solicitação"** do menu lateral (na visão do colaborador, o mesmo item em laranja abre o modal).
- Import `Plus` removido junto, pois ficou sem uso. `Link` foi mantido — ainda é usado nas linhas da tabela de chamados.

Mudança apenas de UI. `vite build` verde e zero erros de tipo em `pages/ti`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
